### PR TITLE
feat: add configurable mode shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Optionally keep the approved plan visible in a docked side panel while implement
 ## Features
 
 - New sessions start in **Build** mode.
-- `Alt+M` cycles **Build → Plan → Build** in every TUI setup. With Pi Plan Build's custom composer active, bare `Tab` also cycles modes while active autocomplete dropdowns retain Pi's normal Tab completion.
+- `Alt+M` cycles **Build → Plan → Build** in every TUI setup. Pi Plan Build leaves Pi's native `Tab` autocomplete behavior unchanged by default; its mode shortcuts are configurable per user.
 - The custom composer uses OpenCode prompt-inspired blue/orange mode colors on the rounded top-left border and left rail, complemented by Pi's border color on the right rail and rounded bottom-right border; rounded corners inherit their vertical rail colors while horizontal `╌` segments bridge the borders at both junctions, paired with a light vertical `┆` at the top right and a mode-specific bottom-left transition: thin `┆` in Plan and heavy `┇` in Build. The active composer and submitted user messages use a continuous solid thin `│` left rail in both modes. These rails use the active Pi theme's `warning` color in Plan and `thinkingLow` color in Build, and submitted messages retain their original mode after mode changes and session restores. Its metadata row shows mode, model, provider, and thinking level; cycling the thinking level updates that row directly.
 - Pi Plan Build leaves the footer untouched; Pi or another installed extension remains responsible for path, usage, model, provider, thinking, and extension-status information.
 - `/plan`, `/build`, and the `--plan` startup flag.
@@ -80,14 +80,40 @@ Do not install more than one npm, Git, or local copy at the same time; duplicate
 
 | Action | Result |
 | --- | --- |
-| `Alt+M` | Cycle Build and Plan in any TUI setup |
-| `Tab` | With the custom composer active, cycle modes or accept an active autocomplete selection |
+| `Alt+M` | Default shortcut to cycle Build and Plan in any TUI setup |
+| Configured editor shortcut | Cycle modes only in Pi Plan Build's custom composer, without intercepting an open autocomplete selection |
 | `/plan` | Resume the unfinished plan, or select a new plan file after completion |
 | `/plan new` | Start a separate task in Plan mode, preserving previous plan files and clearing previous step execution |
 | `/plan done` | In Build mode, explicitly mark the saved plan's implementation complete |
 | `/build` | Select Build mode |
 | `pi --plan` | Start a new session in Plan mode |
 | `/build-fresh` | Start a pending clean-session implementation manually |
+
+### Shortcut configuration
+
+Pi Plan Build reads its user configuration from `~/.pi/agent/pi-plan-build.json` (or `$PI_CODING_AGENT_DIR/pi-plan-build.json`). The default behavior is equivalent to:
+
+```json
+{
+  "shortcuts": {
+    "toggleMode": ["alt+m"],
+    "toggleModeInEditor": []
+  }
+}
+```
+
+`toggleMode` works in every TUI setup. `toggleModeInEditor` works only while Pi Plan Build's custom composer is active. Each action accepts one Pi key string or an array of keys. Use an empty array to disable that action; disable both to remove every Plan Build mode shortcut.
+
+```json
+{
+  "shortcuts": {
+    "toggleMode": "ctrl+alt+m",
+    "toggleModeInEditor": ["ctrl+shift+m"]
+  }
+}
+```
+
+Use Pi's `modifier+key` syntax, such as `ctrl+alt+m`, `shift+tab`, or `f6`. A configured editor key is ignored while Pi displays an autocomplete list, so the normal completion key still accepts the selected item. Configure `"tab"` only when you intentionally want it to switch modes whenever autocomplete is not already open. Run `/reload` after editing the file. Invalid JSON or key strings show a warning and use safe defaults for the affected action.
 
 The agent may also enter Plan mode with `plan_enter` when planning or investigation is safer than immediate execution.
 

--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { CustomEditor, getAgentDir, getMarkdownTheme, parseSkillBlock, type EntryRenderer, type ExtensionAPI, type ExtensionContext, UserMessageComponent } from "@earendil-works/pi-coding-agent";
-import { HStack, Key, Markdown, matchesKey, Text, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
+import { HStack, Markdown, matchesKey, Text, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { registerQuestionTool } from "./question-ui.ts";
+import { loadShortcutConfig } from "./shortcut-config.ts";
 import {
 	buildPlanReminder,
 	buildPlanStepReminder,
@@ -97,6 +98,8 @@ function shorten(filePath: string, cwd: string): string {
 }
 
 export default function planBuildModes(pi: ExtensionAPI): void {
+	const { config: shortcutConfig, path: shortcutConfigPath, warning: shortcutConfigWarning } = loadShortcutConfig(getAgentDir());
+	let shortcutConfigWarningShown = false;
 	let selectedMode: Mode = "build";
 	let runMode: Mode | undefined;
 	let pendingReminder: PendingReminder;
@@ -403,10 +406,12 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 		description: "Switch to Build mode",
 		handler: async (_args, ctx) => selectMode("build", ctx, "manual"),
 	});
-	pi.registerShortcut("alt+m", {
-		description: "Cycle Plan and Build modes",
-		handler: async (ctx) => selectMode(nextMode(selectedMode), ctx, "manual"),
-	});
+	for (const shortcut of shortcutConfig.toggleMode) {
+		pi.registerShortcut(shortcut, {
+			description: "Cycle Plan and Build modes",
+			handler: async (ctx) => selectMode(nextMode(selectedMode), ctx, "manual"),
+		});
+	}
 	pi.registerCommand("build-fresh", {
 		description: "Start a clean linked session and implement the plan selected in plan_exit",
 		handler: async (_args, ctx) => {
@@ -848,6 +853,13 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 	pi.on("session_start", async (event, ctx) => {
 		userMessageRail.activate();
 		currentContext = ctx;
+		if (shortcutConfigWarning && !shortcutConfigWarningShown && ctx.hasUI) {
+			shortcutConfigWarningShown = true;
+			ctx.ui.notify(
+				`Invalid Pi Plan Build shortcut configuration at ${shortcutConfigPath}: ${shortcutConfigWarning}. Safe defaults were used for invalid actions.`,
+				"warning",
+			);
+		}
 		installedEditorFactory = undefined;
 		composerMountingEditorFactory = undefined;
 		reducedOptionalUi = false;
@@ -892,6 +904,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 			class ModeEditor extends CustomEditor {
 				onCycle?: () => void;
 				onCycleThinking?: () => void;
+				matchesModeToggle?: (data: string) => boolean;
 				matchesThinkingCycle?: (data: string) => boolean;
 
 				requestModeRender(): void {
@@ -939,13 +952,13 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 				}
 
 				override handleInput(data: string): void {
+					if (!reducedOptionalUi && !this.isShowingAutocomplete() && this.matchesModeToggle?.(data)) {
+						this.onCycle?.();
+						return;
+					}
 					if (!reducedOptionalUi && this.matchesThinkingCycle?.(data)) {
 						if (this.onExtensionShortcut?.(data)) return;
 						this.onCycleThinking?.();
-						return;
-					}
-					if (!reducedOptionalUi && matchesKey(data, Key.tab) && !this.isShowingAutocomplete()) {
-						this.onCycle?.();
 						return;
 					}
 					super.handleInput(data);
@@ -966,6 +979,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 				editor.onCycle = () => {
 					if (currentContext) void selectMode(nextMode(selectedMode), currentContext, "manual");
 				};
+				editor.matchesModeToggle = (data) => shortcutConfig.toggleModeInEditor.some((shortcut) => matchesKey(data, shortcut));
 				editor.matchesThinkingCycle = (data) =>
 					keybindings.matches(data, "app.thinking.cycle") &&
 					!keybindings.matches(data, "tui.editor.historyPrevious") &&

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "plan-panel.ts",
     "user-message-rail.ts",
     "utils.ts",
+    "shortcut-config.ts",
     "docs/images"
   ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "node --experimental-strip-types --test utils.test.ts question-ui.test.ts plan-execution.test.ts plan-panel.test.ts user-message-rail.test.ts ui-compat.test.ts plan-lifecycle.test.ts",
+    "test": "node --experimental-strip-types --test utils.test.ts shortcut-config.test.ts question-ui.test.ts plan-execution.test.ts plan-panel.test.ts user-message-rail.test.ts ui-compat.test.ts plan-lifecycle.test.ts",
     "prepublishOnly": "npm test"
   },
   "peerDependencies": {

--- a/shortcut-config.test.ts
+++ b/shortcut-config.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { isKeyId, loadShortcutConfig, parseShortcutConfig, SHORTCUT_CONFIG_FILE } from "./shortcut-config.ts";
+
+test("shortcut defaults preserve Alt+M and leave the editor alone", () => {
+	assert.deepEqual(parseShortcutConfig(undefined), {
+		config: {
+			toggleMode: ["alt+m"],
+			toggleModeInEditor: [],
+		},
+	});
+});
+
+test("shortcut configuration accepts remapping and explicit disabling", () => {
+	const result = parseShortcutConfig({
+		shortcuts: {
+			toggleMode: "ctrl+alt+m",
+			toggleModeInEditor: ["ctrl+shift+m", "ctrl++", "ctrl+shift+m"],
+		},
+	});
+
+	assert.deepEqual(result, {
+		config: {
+			toggleMode: ["ctrl+alt+m"],
+			toggleModeInEditor: ["ctrl+shift+m", "ctrl++"],
+		},
+	});
+	assert.deepEqual(parseShortcutConfig({ shortcuts: { toggleMode: [] } }).config.toggleMode, []);
+});
+
+test("invalid shortcut values use defaults only for the invalid action", () => {
+	const result = parseShortcutConfig({
+		shortcuts: {
+			toggleMode: ["cmd+m"],
+			toggleModeInEditor: "ctrl+shift+m",
+		},
+	});
+
+	assert.deepEqual(result.config, {
+		toggleMode: ["alt+m"],
+		toggleModeInEditor: ["ctrl+shift+m"],
+	});
+	assert.match(result.warning ?? "", /shortcuts\.toggleMode/);
+	assert.equal(isKeyId("super+shift+f12"), true);
+	assert.equal(isKeyId("ctrl+ctrl+m"), false);
+});
+
+test("shortcut configuration reads the Pi agent directory and fails safely", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-shortcuts-"));
+	try {
+		assert.deepEqual(loadShortcutConfig(dir), {
+			config: { toggleMode: ["alt+m"], toggleModeInEditor: [] },
+			path: path.join(dir, SHORTCUT_CONFIG_FILE),
+		});
+		fs.writeFileSync(path.join(dir, SHORTCUT_CONFIG_FILE), "{", "utf8");
+		const invalid = loadShortcutConfig(dir);
+		assert.deepEqual(invalid.config, { toggleMode: ["alt+m"], toggleModeInEditor: [] });
+		assert.match(invalid.warning ?? "", /invalid JSON/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/shortcut-config.ts
+++ b/shortcut-config.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { KeyId } from "@earendil-works/pi-tui";
+
+export const SHORTCUT_CONFIG_FILE = "pi-plan-build.json";
+
+const BASE_KEYS = new Set([
+	..."abcdefghijklmnopqrstuvwxyz",
+	..."0123456789",
+	"`", "-", "=", "[", "]", "\\", ";", "'", ",", ".", "/", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "|", "~", "{", "}", ":", "<", ">", "?",
+	"escape", "esc", "enter", "return", "tab", "space", "backspace", "delete", "insert", "clear", "home", "end", "pageUp", "pageDown", "up", "down", "left", "right",
+	"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+]);
+const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+
+export interface ShortcutConfig {
+	toggleMode: KeyId[];
+	toggleModeInEditor: KeyId[];
+}
+
+export interface LoadedShortcutConfig {
+	config: ShortcutConfig;
+	path: string;
+	warning?: string;
+}
+
+const DEFAULT_CONFIG: ShortcutConfig = {
+	toggleMode: ["alt+m"],
+	toggleModeInEditor: [],
+};
+
+function cloneDefaultConfig(): ShortcutConfig {
+	return {
+		toggleMode: [...DEFAULT_CONFIG.toggleMode],
+		toggleModeInEditor: [...DEFAULT_CONFIG.toggleModeInEditor],
+	};
+}
+
+export function isKeyId(value: unknown): value is KeyId {
+	if (typeof value !== "string" || value.length === 0) return false;
+	if (BASE_KEYS.has(value)) return true;
+
+	for (const key of BASE_KEYS) {
+		const suffix = `+${key}`;
+		if (!value.endsWith(suffix)) continue;
+		const modifiers = value.slice(0, -suffix.length).split("+");
+		return modifiers.length > 0
+			&& modifiers.every((modifier) => MODIFIERS.has(modifier))
+			&& new Set(modifiers).size === modifiers.length;
+	}
+	return false;
+}
+
+function parseShortcutList(value: unknown, name: keyof ShortcutConfig): {
+	shortcuts: KeyId[];
+	warning?: string;
+} {
+	if (typeof value === "string") value = [value];
+	if (!Array.isArray(value) || !value.every(isKeyId)) {
+		return {
+			shortcuts: [...DEFAULT_CONFIG[name]],
+			warning: `shortcuts.${name} must be a Pi key string or an array of Pi key strings`,
+		};
+	}
+	return { shortcuts: [...new Set(value)] };
+}
+
+export function parseShortcutConfig(value: unknown): {
+	config: ShortcutConfig;
+	warning?: string;
+} {
+	if (value === undefined) return { config: cloneDefaultConfig() };
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return { config: cloneDefaultConfig(), warning: "the file must contain a JSON object" };
+	}
+
+	const shortcuts = (value as { shortcuts?: unknown }).shortcuts;
+	if (shortcuts === undefined) return { config: cloneDefaultConfig() };
+	if (!shortcuts || typeof shortcuts !== "object" || Array.isArray(shortcuts)) {
+		return { config: cloneDefaultConfig(), warning: "shortcuts must be a JSON object" };
+	}
+
+	const source = shortcuts as Partial<Record<keyof ShortcutConfig, unknown>>;
+	const toggleMode = source.toggleMode === undefined
+		? { shortcuts: [...DEFAULT_CONFIG.toggleMode] }
+		: parseShortcutList(source.toggleMode, "toggleMode");
+	const toggleModeInEditor = source.toggleModeInEditor === undefined
+		? { shortcuts: [...DEFAULT_CONFIG.toggleModeInEditor] }
+		: parseShortcutList(source.toggleModeInEditor, "toggleModeInEditor");
+	const warnings = [toggleMode.warning, toggleModeInEditor.warning].filter((warning): warning is string => warning !== undefined);
+
+	return {
+		config: {
+			toggleMode: toggleMode.shortcuts,
+			toggleModeInEditor: toggleModeInEditor.shortcuts,
+		},
+		...(warnings.length > 0 ? { warning: warnings.join("; ") } : {}),
+	};
+}
+
+export function loadShortcutConfig(agentDir: string): LoadedShortcutConfig {
+	const configPath = path.join(agentDir, SHORTCUT_CONFIG_FILE);
+	let content: string;
+	try {
+		content = fs.readFileSync(configPath, "utf8");
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { config: cloneDefaultConfig(), path: configPath };
+		}
+		return {
+			config: cloneDefaultConfig(),
+			path: configPath,
+			warning: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	try {
+		return { ...parseShortcutConfig(JSON.parse(content)), path: configPath };
+	} catch (error: unknown) {
+		return {
+			config: cloneDefaultConfig(),
+			path: configPath,
+			warning: `invalid JSON (${error instanceof Error ? error.message : String(error)})`,
+		};
+	}
+}

--- a/ui-compat.test.ts
+++ b/ui-compat.test.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import planBuildModes from "./index.ts";
 
-function createHarness(initialEditor?: unknown) {
+function createHarness(initialEditor?: unknown, agentDir?: string) {
 	const handlers = new Map<string, (...args: any[]) => unknown>();
 	const registeredTools = new Map<string, any>();
 	let currentEditor = initialEditor;
 	const editorCalls: unknown[] = [];
+	let createdEditor: any;
 	const statuses: Array<[string, string | undefined]> = [];
 	const notifications: Array<[string, string]> = [];
 	const shortcuts = new Map<string, unknown>();
@@ -50,7 +54,7 @@ function createHarness(initialEditor?: unknown) {
 			setEditorComponent(factory: unknown) {
 				editorCalls.push(factory);
 				currentEditor = factory;
-				if (typeof factory === "function") factory(tui, editorTheme, keybindings);
+				if (typeof factory === "function") createdEditor = factory(tui, editorTheme, keybindings);
 			},
 			setStatus(key: string, text: string | undefined) { statuses.push([key, text]); },
 			notify(message: string, level: string) { notifications.push([message, level]); },
@@ -60,7 +64,14 @@ function createHarness(initialEditor?: unknown) {
 			},
 		},
 	};
-	planBuildModes(pi as any);
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	if (agentDir !== undefined) process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		planBuildModes(pi as any);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
 	return {
 		handlers,
 		ctx,
@@ -69,6 +80,7 @@ function createHarness(initialEditor?: unknown) {
 		notifications,
 		shortcuts,
 		registeredTools,
+		editor: () => createdEditor,
 		setCurrentEditor(value: unknown) { currentEditor = value; },
 		decorateCurrentEditor() {
 			const base = currentEditor as ((...args: any[]) => unknown) | undefined;
@@ -86,11 +98,27 @@ async function shutdown(harness: ReturnType<typeof createHarness>) {
 	await harness.handlers.get("session_shutdown")?.({ reason: "quit" }, harness.ctx);
 }
 
-test("registers Alt+M without taking Pi's Shift+Tab thinking shortcut", () => {
+test("registers default Alt+M without taking Pi's Shift+Tab thinking shortcut", () => {
 	const harness = createHarness();
 	assert.equal(harness.shortcuts.has("alt+m"), true);
 	assert.equal(harness.shortcuts.has("ctrl+tab"), false);
 	assert.equal(harness.shortcuts.has("shift+tab"), false);
+});
+
+test("leaves bare Tab to Pi's custom-editor handling by default", async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-ui-"));
+	try {
+		const harness = createHarness(undefined, dir);
+		await start(harness);
+		const editor = harness.editor();
+		assert.ok(editor, "Pi Plan Build should install its custom editor");
+
+		editor.handleInput("\t");
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.match(editor.render(120).join("\n"), /\*\*build\*\*/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 test("exposes plan_exit in the textual tool inventory metadata", () => {


### PR DESCRIPTION
## Summary
- preserve Pi Tab autocomplete by default
- add user-configurable global and editor-only mode shortcuts
- document configuration and test parsing/input behavior

## Verification
- npm test