### PR TITLE
feat: configurable mode shortcuts and settings presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Optionally keep the approved plan visible in a docked side panel while implement
 ## Features
 
 - New sessions start in **Build** mode.
-- `Alt+M` cycles **Build → Plan → Build** in every TUI setup. With Pi Plan Build's custom composer active, bare `Tab` also cycles modes while active autocomplete dropdowns retain Pi's normal Tab completion.
+- `Alt+M` cycles **Build → Plan → Build** in every TUI setup. Pi Plan Build leaves Pi's native `Tab` autocomplete behavior unchanged by default; its mode shortcuts are configurable per user.
 - The custom composer uses OpenCode prompt-inspired blue/orange mode colors on the rounded top-left border and left rail, complemented by Pi's border color on the right rail and rounded bottom-right border; rounded corners inherit their vertical rail colors while horizontal `╌` segments bridge the borders at both junctions, paired with a light vertical `┆` at the top right and a mode-specific bottom-left transition: thin `┆` in Plan and heavy `┇` in Build. The active composer and submitted user messages use a continuous solid thin `│` left rail in both modes. These rails use the active Pi theme's `warning` color in Plan and `thinkingLow` color in Build, and submitted messages retain their original mode after mode changes and session restores. Its metadata row shows mode, model, provider, and thinking level; cycling the thinking level updates that row directly.
 - Pi Plan Build leaves the footer untouched; Pi or another installed extension remains responsible for path, usage, model, provider, thinking, and extension-status information.
 - `/plan`, `/build`, and the `--plan` startup flag.
@@ -80,14 +80,40 @@ Do not install more than one npm, Git, or local copy at the same time; duplicate
 
 | Action | Result |
 | --- | --- |
-| `Alt+M` | Cycle Build and Plan in any TUI setup |
-| `Tab` | With the custom composer active, cycle modes or accept an active autocomplete selection |
+| `Alt+M` | Default shortcut to cycle Build and Plan in any TUI setup |
+| Configured editor shortcut | Cycle modes only in Pi Plan Build's custom composer, without intercepting an open autocomplete selection |
 | `/plan` | Resume the unfinished plan, or select a new plan file after completion |
 | `/plan new` | Start a separate task in Plan mode, preserving previous plan files and clearing previous step execution |
 | `/plan done` | In Build mode, explicitly mark the saved plan's implementation complete |
 | `/build` | Select Build mode |
 | `pi --plan` | Start a new session in Plan mode |
 | `/build-fresh` | Start a pending clean-session implementation manually |
+
+### Shortcut configuration
+
+Pi Plan Build reads its user configuration from `~/.pi/agent/pi-plan-build.json` (or `$PI_CODING_AGENT_DIR/pi-plan-build.json`). The default behavior is equivalent to:
+
+```json
+{
+  "shortcuts": {
+    "toggleMode": ["alt+m"],
+    "toggleModeInEditor": []
+  }
+}
+```
+
+`toggleMode` works in every TUI setup. `toggleModeInEditor` works only while Pi Plan Build's custom composer is active. Each action accepts one Pi key string or an array of keys. Use an empty array to disable that action; disable both to remove every Plan Build mode shortcut.
+
+```json
+{
+  "shortcuts": {
+    "toggleMode": "ctrl+alt+m",
+    "toggleModeInEditor": ["ctrl+shift+m"]
+  }
+}
+```
+
+Use Pi's `modifier+key` syntax, such as `ctrl+alt+m`, `shift+tab`, or `f6`. A configured editor key is ignored while Pi displays an autocomplete list, so the normal completion key still accepts the selected item. Configure `"tab"` only when you intentionally want it to switch modes whenever autocomplete is not already open. Run `/reload` after editing the file. Invalid JSON or key strings show a warning and use safe defaults for the affected action.
 
 The agent may also enter Plan mode with `plan_enter` when planning or investigation is safer than immediate execution.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Optionally keep the approved plan visible in a docked side panel while implement
 ## Features
 
 - New sessions start in **Build** mode.
-- `Alt+M` cycles **Build → Plan → Build** in every TUI setup. Pi Plan Build leaves Pi's native `Tab` autocomplete behavior unchanged by default; its mode shortcuts are configurable per user.
+- By default, `Alt+M` cycles **Build → Plan → Build** in every TUI setup, and `Tab` also cycles modes in Pi Plan Build's custom composer while autocomplete is closed. An open autocomplete menu keeps normal Tab selection. Use `/plan-settings` to restore Tab-triggered file completion or configure your own shortcuts.
 - The custom composer uses OpenCode prompt-inspired blue/orange mode colors on the rounded top-left border and left rail, complemented by Pi's border color on the right rail and rounded bottom-right border; rounded corners inherit their vertical rail colors while horizontal `╌` segments bridge the borders at both junctions, paired with a light vertical `┆` at the top right and a mode-specific bottom-left transition: thin `┆` in Plan and heavy `┇` in Build. The active composer and submitted user messages use a continuous solid thin `│` left rail in both modes. These rails use the active Pi theme's `warning` color in Plan and `thinkingLow` color in Build, and submitted messages retain their original mode after mode changes and session restores. Its metadata row shows mode, model, provider, and thinking level; cycling the thinking level updates that row directly.
 - Pi Plan Build leaves the footer untouched; Pi or another installed extension remains responsible for path, usage, model, provider, thinking, and extension-status information.
 - `/plan`, `/build`, and the `--plan` startup flag.
@@ -81,7 +81,8 @@ Do not install more than one npm, Git, or local copy at the same time; duplicate
 | Action | Result |
 | --- | --- |
 | `Alt+M` | Default shortcut to cycle Build and Plan in any TUI setup |
-| Configured editor shortcut | Cycle modes only in Pi Plan Build's custom composer, without intercepting an open autocomplete selection |
+| `Tab` (default editor shortcut) | With the custom composer active, cycle modes when autocomplete is closed; accept a suggestion when it is open |
+| `/plan-settings` | Choose a shortcut preset or locate the custom configuration file |
 | `/plan` | Resume the unfinished plan, or select a new plan file after completion |
 | `/plan new` | Start a separate task in Plan mode, preserving previous plan files and clearing previous step execution |
 | `/plan done` | In Build mode, explicitly mark the saved plan's implementation complete |
@@ -91,18 +92,29 @@ Do not install more than one npm, Git, or local copy at the same time; duplicate
 
 ### Shortcut configuration
 
+Run `/plan-settings` to see the active shortcuts and choose:
+
+- **Tab + Alt+M** (default): keep the existing mode-switching workflow.
+- **Alt+M only**: leave Tab entirely to Pi autocomplete.
+- **Disabled**: use `/plan` and `/build` without mode shortcuts.
+- **Custom (edit config file)**: show the file path and an example without changing your configuration.
+
+Presets update the same configuration file used for custom shortcuts and preserve unrelated settings. Cancel makes no changes. Run `/reload` after saving a preset or manually editing the file; the active shortcuts stay unchanged until reload. The selector refuses to overwrite malformed JSON.
+
+**Tab tradeoff:** Pi normally uses Tab to request file completion even with no menu open (for example, `Review READ` + Tab can suggest `README.md`). The default editor shortcut intentionally replaces that action with mode switching. It does not interfere with accepting a suggestion from an already-open menu. Choose **Alt+M only** if you use Tab to request completion.
+
 Pi Plan Build reads its user configuration from `~/.pi/agent/pi-plan-build.json` (or `$PI_CODING_AGENT_DIR/pi-plan-build.json`). The default behavior is equivalent to:
 
 ```json
 {
   "shortcuts": {
     "toggleMode": ["alt+m"],
-    "toggleModeInEditor": []
+    "toggleModeInEditor": ["tab"]
   }
 }
 ```
 
-`toggleMode` works in every TUI setup. `toggleModeInEditor` works only while Pi Plan Build's custom composer is active. Each action accepts one Pi key string or an array of keys. Use an empty array to disable that action; disable both to remove every Plan Build mode shortcut.
+`toggleMode` registers global shortcuts through Pi and follows Pi's built-in conflict rules: reserved shortcuts may be skipped with a warning. `toggleModeInEditor` works only while Pi Plan Build's custom composer is active and yields while autocomplete is open. Each action accepts one Pi key string or an array of keys. Use an empty array to disable that action; disable both to remove every Plan Build mode shortcut. Omitted actions retain their defaults. For Alt+M only, set `toggleModeInEditor` to `[]`.
 
 ```json
 {
@@ -113,7 +125,9 @@ Pi Plan Build reads its user configuration from `~/.pi/agent/pi-plan-build.json`
 }
 ```
 
-Use Pi's `modifier+key` syntax, such as `ctrl+alt+m`, `shift+tab`, or `f6`. A configured editor key is ignored while Pi displays an autocomplete list, so the normal completion key still accepts the selected item. Configure `"tab"` only when you intentionally want it to switch modes whenever autocomplete is not already open. Run `/reload` after editing the file. Invalid JSON or key strings show a warning and use safe defaults for the affected action.
+Use lowercase Pi `modifier+key` syntax, such as `ctrl+alt+m`, `ctrl+shift+m`, or `f6` (navigation names include `pageUp` and `pageDown`). Put bare `"tab"` only in `toggleModeInEditor`; a global Tab binding is rejected because it would intercept open-menu completion too. Avoid assigning the same key to both actions if you want editor-only autocomplete protection: global shortcuts still run while a menu is open.
+
+Known unsupported matcher forms, including `+`/`ctrl++`, modified Escape, and modified function keys, are rejected. Advanced modifier combinations depend on terminal support; legacy terminals may report different key combinations identically. Invalid JSON or key strings show a warning and use the defaults above for affected actions, including Tab for an invalid editor action.
 
 The agent may also enter Plan mode with `plan_enter` when planning or investigation is safer than immediate execution.
 

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import { CustomEditor, getAgentDir, getMarkdownTheme, parseSkillBlock, type Entr
 import { HStack, Markdown, matchesKey, Text, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { registerQuestionTool } from "./question-ui.ts";
-import { loadShortcutConfig } from "./shortcut-config.ts";
+import { loadShortcutConfig, saveShortcutPreset, SHORTCUT_PRESETS, shortcutPresetLabel } from "./shortcut-config.ts";
 import {
 	buildPlanReminder,
 	buildPlanStepReminder,
@@ -98,7 +98,8 @@ function shorten(filePath: string, cwd: string): string {
 }
 
 export default function planBuildModes(pi: ExtensionAPI): void {
-	const { config: shortcutConfig, path: shortcutConfigPath, warning: shortcutConfigWarning } = loadShortcutConfig(getAgentDir());
+	const shortcutAgentDir = getAgentDir();
+	const { config: shortcutConfig, path: shortcutConfigPath, warning: shortcutConfigWarning } = loadShortcutConfig(shortcutAgentDir);
 	let shortcutConfigWarningShown = false;
 	let selectedMode: Mode = "build";
 	let runMode: Mode | undefined;
@@ -210,7 +211,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 		if (!reducedUiNoticeShown) {
 			reducedUiNoticeShown = true;
 			ctx.ui.notify(
-				"Another extension owns Pi's custom editor or fullscreen layout. Pi Plan Build disabled its custom composer and experimental step-by-step panel; Plan and Build workflows remain available through Alt+M, /plan, and /build.",
+				`Another extension owns Pi's custom editor or fullscreen layout. Pi Plan Build disabled its custom composer and experimental step-by-step panel; Plan and Build workflows remain available through ${shortcutConfig.toggleMode.length ? `${shortcutConfig.toggleMode.join(", ")}, ` : ""}/plan, and /build.`,
 				"warning",
 			);
 		}
@@ -405,6 +406,31 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 	pi.registerCommand("build", {
 		description: "Switch to Build mode",
 		handler: async (_args, ctx) => selectMode("build", ctx, "manual"),
+	});
+	pi.registerCommand("plan-settings", {
+		description: "Choose Plan/Build shortcuts or locate the custom shortcut configuration",
+		handler: async (_args, ctx) => {
+			if (!ctx.hasUI) return;
+			const customOption = "Custom (edit config file)";
+			const selected = await ctx.ui.select(
+				`Plan/Build shortcuts — active: ${shortcutPresetLabel(shortcutConfig)} (global: ${shortcutConfig.toggleMode.join(", ") || "none"}; editor: ${shortcutConfig.toggleModeInEditor.join(", ") || "none"})`,
+				[...Object.keys(SHORTCUT_PRESETS), customOption],
+			);
+			if (!selected) return;
+			if (selected === customOption) {
+				ctx.ui.notify(
+					`Edit ${shortcutConfigPath}, then run /reload. Example: {"shortcuts":{"toggleMode":["ctrl+alt+m"],"toggleModeInEditor":["tab"]}}. Use [] to disable an action. Put Tab only in toggleModeInEditor; it switches modes when autocomplete is closed instead of requesting file completion.`,
+					"info",
+				);
+				return;
+			}
+			try {
+				saveShortcutPreset(shortcutAgentDir, selected);
+				ctx.ui.notify(`Saved ${selected} to ${shortcutConfigPath}. Run /reload to apply the shortcuts.`, "info");
+			} catch (error) {
+				ctx.ui.notify(`Could not save ${shortcutConfigPath}: ${error instanceof Error ? error.message : String(error)}`, "error");
+			}
+		},
 	});
 	for (const shortcut of shortcutConfig.toggleMode) {
 		pi.registerShortcut(shortcut, {
@@ -856,7 +882,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 		if (shortcutConfigWarning && !shortcutConfigWarningShown && ctx.hasUI) {
 			shortcutConfigWarningShown = true;
 			ctx.ui.notify(
-				`Invalid Pi Plan Build shortcut configuration at ${shortcutConfigPath}: ${shortcutConfigWarning}. Safe defaults were used for invalid actions.`,
+				`Invalid Pi Plan Build shortcut configuration at ${shortcutConfigPath}: ${shortcutConfigWarning}. Default shortcuts were used for invalid actions.`,
 				"warning",
 			);
 		}

--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { CustomEditor, getAgentDir, getMarkdownTheme, parseSkillBlock, type EntryRenderer, type ExtensionAPI, type ExtensionContext, UserMessageComponent } from "@earendil-works/pi-coding-agent";
-import { HStack, Key, Markdown, matchesKey, Text, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
+import { HStack, Markdown, matchesKey, Text, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { registerQuestionTool } from "./question-ui.ts";
+import { loadShortcutConfig } from "./shortcut-config.ts";
 import {
 	buildPlanReminder,
 	buildPlanStepReminder,
@@ -97,6 +98,8 @@ function shorten(filePath: string, cwd: string): string {
 }
 
 export default function planBuildModes(pi: ExtensionAPI): void {
+	const { config: shortcutConfig, path: shortcutConfigPath, warning: shortcutConfigWarning } = loadShortcutConfig(getAgentDir());
+	let shortcutConfigWarningShown = false;
 	let selectedMode: Mode = "build";
 	let runMode: Mode | undefined;
 	let pendingReminder: PendingReminder;
@@ -403,10 +406,12 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 		description: "Switch to Build mode",
 		handler: async (_args, ctx) => selectMode("build", ctx, "manual"),
 	});
-	pi.registerShortcut("alt+m", {
-		description: "Cycle Plan and Build modes",
-		handler: async (ctx) => selectMode(nextMode(selectedMode), ctx, "manual"),
-	});
+	for (const shortcut of shortcutConfig.toggleMode) {
+		pi.registerShortcut(shortcut, {
+			description: "Cycle Plan and Build modes",
+			handler: async (ctx) => selectMode(nextMode(selectedMode), ctx, "manual"),
+		});
+	}
 	pi.registerCommand("build-fresh", {
 		description: "Start a clean linked session and implement the plan selected in plan_exit",
 		handler: async (_args, ctx) => {
@@ -848,6 +853,13 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 	pi.on("session_start", async (event, ctx) => {
 		userMessageRail.activate();
 		currentContext = ctx;
+		if (shortcutConfigWarning && !shortcutConfigWarningShown && ctx.hasUI) {
+			shortcutConfigWarningShown = true;
+			ctx.ui.notify(
+				`Invalid Pi Plan Build shortcut configuration at ${shortcutConfigPath}: ${shortcutConfigWarning}. Safe defaults were used for invalid actions.`,
+				"warning",
+			);
+		}
 		installedEditorFactory = undefined;
 		composerMountingEditorFactory = undefined;
 		reducedOptionalUi = false;
@@ -892,6 +904,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 			class ModeEditor extends CustomEditor {
 				onCycle?: () => void;
 				onCycleThinking?: () => void;
+				matchesModeToggle?: (data: string) => boolean;
 				matchesThinkingCycle?: (data: string) => boolean;
 
 				requestModeRender(): void {
@@ -939,13 +952,13 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 				}
 
 				override handleInput(data: string): void {
+					if (!reducedOptionalUi && !this.isShowingAutocomplete() && this.matchesModeToggle?.(data)) {
+						this.onCycle?.();
+						return;
+					}
 					if (!reducedOptionalUi && this.matchesThinkingCycle?.(data)) {
 						if (this.onExtensionShortcut?.(data)) return;
 						this.onCycleThinking?.();
-						return;
-					}
-					if (!reducedOptionalUi && matchesKey(data, Key.tab) && !this.isShowingAutocomplete()) {
-						this.onCycle?.();
 						return;
 					}
 					super.handleInput(data);
@@ -966,6 +979,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 				editor.onCycle = () => {
 					if (currentContext) void selectMode(nextMode(selectedMode), currentContext, "manual");
 				};
+				editor.matchesModeToggle = (data) => shortcutConfig.toggleModeInEditor.some((shortcut) => matchesKey(data, shortcut));
 				editor.matchesThinkingCycle = (data) =>
 					keybindings.matches(data, "app.thinking.cycle") &&
 					!keybindings.matches(data, "tui.editor.historyPrevious") &&

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "plan-panel.ts",
     "user-message-rail.ts",
     "utils.ts",
+    "shortcut-config.ts",
     "docs/images"
   ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "node --experimental-strip-types --test utils.test.ts question-ui.test.ts plan-execution.test.ts plan-panel.test.ts user-message-rail.test.ts ui-compat.test.ts plan-lifecycle.test.ts",
+    "test": "node --experimental-strip-types --test utils.test.ts shortcut-config.test.ts question-ui.test.ts plan-execution.test.ts plan-panel.test.ts user-message-rail.test.ts ui-compat.test.ts plan-lifecycle.test.ts",
     "prepublishOnly": "npm test"
   },
   "peerDependencies": {

--- a/shortcut-config.test.ts
+++ b/shortcut-config.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { isKeyId, loadShortcutConfig, parseShortcutConfig, SHORTCUT_CONFIG_FILE } from "./shortcut-config.ts";
+
+test("shortcut defaults preserve Alt+M and leave the editor alone", () => {
+	assert.deepEqual(parseShortcutConfig(undefined), {
+		config: {
+			toggleMode: ["alt+m"],
+			toggleModeInEditor: [],
+		},
+	});
+});
+
+test("shortcut configuration accepts remapping and explicit disabling", () => {
+	const result = parseShortcutConfig({
+		shortcuts: {
+			toggleMode: "ctrl+alt+m",
+			toggleModeInEditor: ["ctrl+shift+m", "ctrl++", "ctrl+shift+m"],
+		},
+	});
+
+	assert.deepEqual(result, {
+		config: {
+			toggleMode: ["ctrl+alt+m"],
+			toggleModeInEditor: ["ctrl+shift+m", "ctrl++"],
+		},
+	});
+	assert.deepEqual(parseShortcutConfig({ shortcuts: { toggleMode: [] } }).config.toggleMode, []);
+});
+
+test("invalid shortcut values use defaults only for the invalid action", () => {
+	const result = parseShortcutConfig({
+		shortcuts: {
+			toggleMode: ["cmd+m"],
+			toggleModeInEditor: "ctrl+shift+m",
+		},
+	});
+
+	assert.deepEqual(result.config, {
+		toggleMode: ["alt+m"],
+		toggleModeInEditor: ["ctrl+shift+m"],
+	});
+	assert.match(result.warning ?? "", /shortcuts\.toggleMode/);
+	assert.equal(isKeyId("super+shift+f12"), true);
+	assert.equal(isKeyId("ctrl+ctrl+m"), false);
+});
+
+test("shortcut configuration reads the Pi agent directory and fails safely", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-shortcuts-"));
+	try {
+		assert.deepEqual(loadShortcutConfig(dir), {
+			config: { toggleMode: ["alt+m"], toggleModeInEditor: [] },
+			path: path.join(dir, SHORTCUT_CONFIG_FILE),
+		});
+		fs.writeFileSync(path.join(dir, SHORTCUT_CONFIG_FILE), "{", "utf8");
+		const invalid = loadShortcutConfig(dir);
+		assert.deepEqual(invalid.config, { toggleMode: ["alt+m"], toggleModeInEditor: [] });
+		assert.match(invalid.warning ?? "", /invalid JSON/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/shortcut-config.test.ts
+++ b/shortcut-config.test.ts
@@ -3,13 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { isKeyId, loadShortcutConfig, parseShortcutConfig, SHORTCUT_CONFIG_FILE } from "./shortcut-config.ts";
+import { matchesKey } from "@earendil-works/pi-tui";
+import { isKeyId, loadShortcutConfig, parseShortcutConfig, saveShortcutPreset, SHORTCUT_CONFIG_FILE, SHORTCUT_PRESETS, shortcutPresetLabel } from "./shortcut-config.ts";
 
-test("shortcut defaults preserve Alt+M and leave the editor alone", () => {
+test("shortcut defaults preserve Tab and Alt+M", () => {
 	assert.deepEqual(parseShortcutConfig(undefined), {
 		config: {
 			toggleMode: ["alt+m"],
-			toggleModeInEditor: [],
+			toggleModeInEditor: ["tab"],
 		},
 	});
 });
@@ -18,14 +19,14 @@ test("shortcut configuration accepts remapping and explicit disabling", () => {
 	const result = parseShortcutConfig({
 		shortcuts: {
 			toggleMode: "ctrl+alt+m",
-			toggleModeInEditor: ["ctrl+shift+m", "ctrl++", "ctrl+shift+m"],
+			toggleModeInEditor: ["ctrl+shift+m", "f6", "ctrl+shift+m"],
 		},
 	});
 
 	assert.deepEqual(result, {
 		config: {
 			toggleMode: ["ctrl+alt+m"],
-			toggleModeInEditor: ["ctrl+shift+m", "ctrl++"],
+			toggleModeInEditor: ["ctrl+shift+m", "f6"],
 		},
 	});
 	assert.deepEqual(parseShortcutConfig({ shortcuts: { toggleMode: [] } }).config.toggleMode, []);
@@ -44,20 +45,74 @@ test("invalid shortcut values use defaults only for the invalid action", () => {
 		toggleModeInEditor: ["ctrl+shift+m"],
 	});
 	assert.match(result.warning ?? "", /shortcuts\.toggleMode/);
-	assert.equal(isKeyId("super+shift+f12"), true);
-	assert.equal(isKeyId("ctrl+ctrl+m"), false);
+	for (const key of ["super+shift+f12", "ctrl+ctrl+m", "ctrl++", "+", "alt+escape"]) {
+		assert.equal(isKeyId(key), false, key);
+	}
+	for (const [key, data] of [["ctrl+shift+m", "\x1b[109;6u"], ["f6", "\x1b[17~"], ["super+k", "\x1b[107;9u"]]) {
+		assert.ok(isKeyId(key));
+		assert.ok(matchesKey(data!, key), `${key} must be supported by Pi's matcher`);
+	}
+	const invalidEditor = parseShortcutConfig({ shortcuts: { toggleMode: [], toggleModeInEditor: "ctrl++" } });
+	assert.deepEqual(invalidEditor.config, { toggleMode: [], toggleModeInEditor: ["tab"] });
+	assert.match(invalidEditor.warning ?? "", /shortcuts\.toggleModeInEditor/);
+});
+
+test("global Tab uses the global default and explains the editor-only alternative", () => {
+	const result = parseShortcutConfig({ shortcuts: { toggleMode: ["tab"], toggleModeInEditor: [] } });
+	assert.deepEqual(result.config, { toggleMode: ["alt+m"], toggleModeInEditor: [] });
+	assert.match(result.warning ?? "", /put tab in shortcuts\.toggleModeInEditor/);
+});
+
+test("presets round-trip, preserve unrelated settings, and identify custom bindings", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-shortcuts-"));
+	try {
+		const file = path.join(dir, SHORTCUT_CONFIG_FILE);
+		fs.writeFileSync(file, JSON.stringify({ unrelated: { enabled: true }, shortcuts: { futureAction: ["f7"] } }));
+		for (const [label, config] of Object.entries(SHORTCUT_PRESETS)) {
+			assert.equal(saveShortcutPreset(dir, label), file);
+			assert.deepEqual(loadShortcutConfig(dir).config, config);
+			assert.equal(shortcutPresetLabel(loadShortcutConfig(dir).config), label);
+			const saved = JSON.parse(fs.readFileSync(file, "utf8"));
+			assert.deepEqual(saved.unrelated, { enabled: true });
+			assert.deepEqual(saved.shortcuts.futureAction, ["f7"]);
+			assert.deepEqual(fs.readdirSync(dir), [SHORTCUT_CONFIG_FILE], "atomic save leaves no temporary file");
+		}
+		assert.equal(shortcutPresetLabel({ toggleMode: ["f6"], toggleModeInEditor: [] }), "Custom");
+		const newDir = path.join(dir, "new-agent-dir");
+		saveShortcutPreset(newDir, "Tab + Alt+M");
+		assert.equal(shortcutPresetLabel(loadShortcutConfig(newDir).config), "Tab + Alt+M");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("saving refuses malformed files and reports filesystem failures", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-shortcuts-"));
+	try {
+		const file = path.join(dir, SHORTCUT_CONFIG_FILE);
+		for (const malformed of ["{", "[]", '{"shortcuts":[]}']) {
+			fs.writeFileSync(file, malformed);
+			assert.throws(() => saveShortcutPreset(dir, "Alt+M only"));
+			assert.equal(fs.readFileSync(file, "utf8"), malformed);
+		}
+		// A regular file cannot be used as an agent directory (works even as root).
+		assert.throws(() => saveShortcutPreset(file, "Alt+M only"));
+		assert.match(loadShortcutConfig(file).warning ?? "", /ENOTDIR/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 test("shortcut configuration reads the Pi agent directory and fails safely", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-shortcuts-"));
 	try {
 		assert.deepEqual(loadShortcutConfig(dir), {
-			config: { toggleMode: ["alt+m"], toggleModeInEditor: [] },
+			config: { toggleMode: ["alt+m"], toggleModeInEditor: ["tab"] },
 			path: path.join(dir, SHORTCUT_CONFIG_FILE),
 		});
 		fs.writeFileSync(path.join(dir, SHORTCUT_CONFIG_FILE), "{", "utf8");
 		const invalid = loadShortcutConfig(dir);
-		assert.deepEqual(invalid.config, { toggleMode: ["alt+m"], toggleModeInEditor: [] });
+		assert.deepEqual(invalid.config, { toggleMode: ["alt+m"], toggleModeInEditor: ["tab"] });
 		assert.match(invalid.warning ?? "", /invalid JSON/);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });

--- a/shortcut-config.ts
+++ b/shortcut-config.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { KeyId } from "@earendil-works/pi-tui";
+
+export const SHORTCUT_CONFIG_FILE = "pi-plan-build.json";
+
+const BASE_KEYS = new Set([
+	..."abcdefghijklmnopqrstuvwxyz",
+	..."0123456789",
+	"`", "-", "=", "[", "]", "\\", ";", "'", ",", ".", "/", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "|", "~", "{", "}", ":", "<", ">", "?",
+	"escape", "esc", "enter", "return", "tab", "space", "backspace", "delete", "insert", "clear", "home", "end", "pageUp", "pageDown", "up", "down", "left", "right",
+	"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+]);
+const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+
+export interface ShortcutConfig {
+	toggleMode: KeyId[];
+	toggleModeInEditor: KeyId[];
+}
+
+export interface LoadedShortcutConfig {
+	config: ShortcutConfig;
+	path: string;
+	warning?: string;
+}
+
+const DEFAULT_CONFIG: ShortcutConfig = {
+	toggleMode: ["alt+m"],
+	toggleModeInEditor: [],
+};
+
+function cloneDefaultConfig(): ShortcutConfig {
+	return {
+		toggleMode: [...DEFAULT_CONFIG.toggleMode],
+		toggleModeInEditor: [...DEFAULT_CONFIG.toggleModeInEditor],
+	};
+}
+
+export function isKeyId(value: unknown): value is KeyId {
+	if (typeof value !== "string" || value.length === 0) return false;
+	if (BASE_KEYS.has(value)) return true;
+
+	for (const key of BASE_KEYS) {
+		const suffix = `+${key}`;
+		if (!value.endsWith(suffix)) continue;
+		const modifiers = value.slice(0, -suffix.length).split("+");
+		return modifiers.length > 0
+			&& modifiers.every((modifier) => MODIFIERS.has(modifier))
+			&& new Set(modifiers).size === modifiers.length;
+	}
+	return false;
+}
+
+function parseShortcutList(value: unknown, name: keyof ShortcutConfig): {
+	shortcuts: KeyId[];
+	warning?: string;
+} {
+	if (typeof value === "string") value = [value];
+	if (!Array.isArray(value) || !value.every(isKeyId)) {
+		return {
+			shortcuts: [...DEFAULT_CONFIG[name]],
+			warning: `shortcuts.${name} must be a Pi key string or an array of Pi key strings`,
+		};
+	}
+	return { shortcuts: [...new Set(value)] };
+}
+
+export function parseShortcutConfig(value: unknown): {
+	config: ShortcutConfig;
+	warning?: string;
+} {
+	if (value === undefined) return { config: cloneDefaultConfig() };
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return { config: cloneDefaultConfig(), warning: "the file must contain a JSON object" };
+	}
+
+	const shortcuts = (value as { shortcuts?: unknown }).shortcuts;
+	if (shortcuts === undefined) return { config: cloneDefaultConfig() };
+	if (!shortcuts || typeof shortcuts !== "object" || Array.isArray(shortcuts)) {
+		return { config: cloneDefaultConfig(), warning: "shortcuts must be a JSON object" };
+	}
+
+	const source = shortcuts as Partial<Record<keyof ShortcutConfig, unknown>>;
+	const toggleMode = source.toggleMode === undefined
+		? { shortcuts: [...DEFAULT_CONFIG.toggleMode] }
+		: parseShortcutList(source.toggleMode, "toggleMode");
+	const toggleModeInEditor = source.toggleModeInEditor === undefined
+		? { shortcuts: [...DEFAULT_CONFIG.toggleModeInEditor] }
+		: parseShortcutList(source.toggleModeInEditor, "toggleModeInEditor");
+	const warnings = [toggleMode.warning, toggleModeInEditor.warning].filter((warning): warning is string => warning !== undefined);
+
+	return {
+		config: {
+			toggleMode: toggleMode.shortcuts,
+			toggleModeInEditor: toggleModeInEditor.shortcuts,
+		},
+		...(warnings.length > 0 ? { warning: warnings.join("; ") } : {}),
+	};
+}
+
+export function loadShortcutConfig(agentDir: string): LoadedShortcutConfig {
+	const configPath = path.join(agentDir, SHORTCUT_CONFIG_FILE);
+	let content: string;
+	try {
+		content = fs.readFileSync(configPath, "utf8");
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { config: cloneDefaultConfig(), path: configPath };
+		}
+		return {
+			config: cloneDefaultConfig(),
+			path: configPath,
+			warning: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	try {
+		return { ...parseShortcutConfig(JSON.parse(content)), path: configPath };
+	} catch (error: unknown) {
+		return {
+			config: cloneDefaultConfig(),
+			path: configPath,
+			warning: `invalid JSON (${error instanceof Error ? error.message : String(error)})`,
+		};
+	}
+}

--- a/shortcut-config.ts
+++ b/shortcut-config.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { KeyId } from "@earendil-works/pi-tui";
@@ -7,7 +8,7 @@ export const SHORTCUT_CONFIG_FILE = "pi-plan-build.json";
 const BASE_KEYS = new Set([
 	..."abcdefghijklmnopqrstuvwxyz",
 	..."0123456789",
-	"`", "-", "=", "[", "]", "\\", ";", "'", ",", ".", "/", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "|", "~", "{", "}", ":", "<", ">", "?",
+	"`", "-", "=", "[", "]", "\\", ";", "'", ",", ".", "/", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "|", "~", "{", "}", ":", "<", ">", "?",
 	"escape", "esc", "enter", "return", "tab", "space", "backspace", "delete", "insert", "clear", "home", "end", "pageUp", "pageDown", "up", "down", "left", "right",
 	"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
 ]);
@@ -26,8 +27,22 @@ export interface LoadedShortcutConfig {
 
 const DEFAULT_CONFIG: ShortcutConfig = {
 	toggleMode: ["alt+m"],
-	toggleModeInEditor: [],
+	toggleModeInEditor: ["tab"],
 };
+
+export const SHORTCUT_PRESETS: Record<string, ShortcutConfig> = {
+	"Tab + Alt+M": DEFAULT_CONFIG,
+	"Alt+M only": { toggleMode: ["alt+m"], toggleModeInEditor: [] },
+	"Disabled": { toggleMode: [], toggleModeInEditor: [] },
+};
+
+export function shortcutPresetLabel(config: ShortcutConfig): string {
+	return Object.entries(SHORTCUT_PRESETS).find(([, preset]) =>
+		(["toggleMode", "toggleModeInEditor"] as const).every((action) =>
+			config[action].length === preset[action].length && config[action].every((key) => preset[action].includes(key)),
+		),
+	)?.[0] ?? "Custom";
+}
 
 function cloneDefaultConfig(): ShortcutConfig {
 	return {
@@ -43,6 +58,8 @@ export function isKeyId(value: unknown): value is KeyId {
 	for (const key of BASE_KEYS) {
 		const suffix = `+${key}`;
 		if (!value.endsWith(suffix)) continue;
+		// Pi's matcher currently rejects modified Escape and function keys.
+		if (key === "escape" || key === "esc" || /^f\d+$/.test(key)) return false;
 		const modifiers = value.slice(0, -suffix.length).split("+");
 		return modifiers.length > 0
 			&& modifiers.every((modifier) => MODIFIERS.has(modifier))
@@ -60,6 +77,12 @@ function parseShortcutList(value: unknown, name: keyof ShortcutConfig): {
 		return {
 			shortcuts: [...DEFAULT_CONFIG[name]],
 			warning: `shortcuts.${name} must be a Pi key string or an array of Pi key strings`,
+		};
+	}
+	if (name === "toggleMode" && value.includes("tab")) {
+		return {
+			shortcuts: [...DEFAULT_CONFIG[name]],
+			warning: "put tab in shortcuts.toggleModeInEditor, not shortcuts.toggleMode, to preserve open-menu autocomplete",
 		};
 	}
 	return { shortcuts: [...new Set(value)] };
@@ -96,6 +119,38 @@ export function parseShortcutConfig(value: unknown): {
 		},
 		...(warnings.length > 0 ? { warning: warnings.join("; ") } : {}),
 	};
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Preserve unrelated settings and never replace malformed configuration with defaults. */
+export function saveShortcutPreset(agentDir: string, presetName: string): string {
+	if (!Object.hasOwn(SHORTCUT_PRESETS, presetName)) throw new Error("Unknown shortcut preset");
+	const configPath = path.join(agentDir, SHORTCUT_CONFIG_FILE);
+	let document: unknown = {};
+	try {
+		document = JSON.parse(fs.readFileSync(configPath, "utf8"));
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	if (!isObject(document) || (document.shortcuts !== undefined && !isObject(document.shortcuts))) {
+		throw new Error("The configuration and shortcuts must be JSON objects; fix the file before saving a preset");
+	}
+	const next = {
+		...document,
+		shortcuts: { ...(document.shortcuts as Record<string, unknown> | undefined), ...SHORTCUT_PRESETS[presetName] },
+	};
+	fs.mkdirSync(agentDir, { recursive: true });
+	const temporaryPath = `${configPath}.${randomUUID()}.tmp`;
+	try {
+		fs.writeFileSync(temporaryPath, `${JSON.stringify(next, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+		fs.renameSync(temporaryPath, configPath);
+	} finally {
+		fs.rmSync(temporaryPath, { force: true });
+	}
+	return configPath;
 }
 
 export function loadShortcutConfig(agentDir: string): LoadedShortcutConfig {

--- a/ui-compat.test.ts
+++ b/ui-compat.test.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import planBuildModes from "./index.ts";
 
-function createHarness(initialEditor?: unknown) {
+function createHarness(initialEditor?: unknown, agentDir?: string) {
 	const handlers = new Map<string, (...args: any[]) => unknown>();
 	const registeredTools = new Map<string, any>();
 	let currentEditor = initialEditor;
 	const editorCalls: unknown[] = [];
+	let createdEditor: any;
 	const statuses: Array<[string, string | undefined]> = [];
 	const notifications: Array<[string, string]> = [];
 	const shortcuts = new Map<string, unknown>();
@@ -50,7 +54,7 @@ function createHarness(initialEditor?: unknown) {
 			setEditorComponent(factory: unknown) {
 				editorCalls.push(factory);
 				currentEditor = factory;
-				if (typeof factory === "function") factory(tui, editorTheme, keybindings);
+				if (typeof factory === "function") createdEditor = factory(tui, editorTheme, keybindings);
 			},
 			setStatus(key: string, text: string | undefined) { statuses.push([key, text]); },
 			notify(message: string, level: string) { notifications.push([message, level]); },
@@ -60,7 +64,14 @@ function createHarness(initialEditor?: unknown) {
 			},
 		},
 	};
-	planBuildModes(pi as any);
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	if (agentDir !== undefined) process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		planBuildModes(pi as any);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
 	return {
 		handlers,
 		ctx,
@@ -69,6 +80,7 @@ function createHarness(initialEditor?: unknown) {
 		notifications,
 		shortcuts,
 		registeredTools,
+		editor: () => createdEditor,
 		setCurrentEditor(value: unknown) { currentEditor = value; },
 		decorateCurrentEditor() {
 			const base = currentEditor as ((...args: any[]) => unknown) | undefined;
@@ -86,11 +98,27 @@ async function shutdown(harness: ReturnType<typeof createHarness>) {
 	await harness.handlers.get("session_shutdown")?.({ reason: "quit" }, harness.ctx);
 }
 
-test("registers Alt+M without taking Pi's Shift+Tab thinking shortcut", () => {
+test("registers default Alt+M without taking Pi's Shift+Tab thinking shortcut", () => {
 	const harness = createHarness();
 	assert.equal(harness.shortcuts.has("alt+m"), true);
 	assert.equal(harness.shortcuts.has("ctrl+tab"), false);
 	assert.equal(harness.shortcuts.has("shift+tab"), false);
+});
+
+test("leaves bare Tab to Pi's custom-editor handling by default", async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-ui-"));
+	try {
+		const harness = createHarness(undefined, dir);
+		await start(harness);
+		const editor = harness.editor();
+		assert.ok(editor, "Pi Plan Build should install its custom editor");
+
+		editor.handleInput("\t");
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.match(editor.render(120).join("\n"), /\*\*build\*\*/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 test("exposes plan_exit in the textual tool inventory metadata", () => {

--- a/ui-compat.test.ts
+++ b/ui-compat.test.ts
@@ -2,10 +2,30 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { afterEach, beforeEach } from "node:test";
+import { CombinedAutocompleteProvider, matchesKey } from "@earendil-works/pi-tui";
 import planBuildModes from "./index.ts";
+import { loadShortcutConfig, SHORTCUT_CONFIG_FILE } from "./shortcut-config.ts";
 
-function createHarness(initialEditor?: unknown, agentDir?: string) {
+let agentDir: string;
+let previousAgentDir: string | undefined;
+const runningHarnesses = new Set<ReturnType<typeof createHarness>>();
+beforeEach(() => {
+	agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-ui-"));
+	previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+});
+afterEach(async () => {
+	try {
+		for (const harness of runningHarnesses) await shutdown(harness);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		fs.rmSync(agentDir, { recursive: true, force: true });
+	}
+});
+
+function createHarness(initialEditor?: unknown) {
 	const handlers = new Map<string, (...args: any[]) => unknown>();
 	const registeredTools = new Map<string, any>();
 	let currentEditor = initialEditor;
@@ -13,7 +33,12 @@ function createHarness(initialEditor?: unknown, agentDir?: string) {
 	let createdEditor: any;
 	const statuses: Array<[string, string | undefined]> = [];
 	const notifications: Array<[string, string]> = [];
-	const shortcuts = new Map<string, unknown>();
+	const shortcuts = new Map<string, any>();
+	const commands = new Map<string, any>();
+	const selections: Array<{ title: string; options: string[] }> = [];
+	let selectedOption: string | undefined;
+	let resolvePersist: (() => void) | undefined;
+	const persisted: any[] = [];
 	let activeTools = ["read", "bash", "edit", "write"];
 	const tui = {
 		requestRender() {},
@@ -30,13 +55,17 @@ function createHarness(initialEditor?: unknown, agentDir?: string) {
 		},
 		registerFlag() {},
 		registerTool(definition: any) { registeredTools.set(definition.name, definition); },
-		registerCommand() {},
+		registerCommand(name: string, options: unknown) { commands.set(name, options); },
 		registerShortcut(key: string, options: unknown) { shortcuts.set(key, options); },
 		registerEntryRenderer() {},
 		getFlag() { return false; },
 		getActiveTools() { return [...activeTools]; },
 		setActiveTools(next: string[]) { activeTools = [...next]; },
-		appendEntry() {},
+		appendEntry(_type: string, data: unknown) {
+			persisted.push(data);
+			resolvePersist?.();
+			resolvePersist = undefined;
+		},
 		getThinkingLevel() { return "medium"; },
 	};
 	const ctx = {
@@ -54,24 +83,32 @@ function createHarness(initialEditor?: unknown, agentDir?: string) {
 			setEditorComponent(factory: unknown) {
 				editorCalls.push(factory);
 				currentEditor = factory;
-				if (typeof factory === "function") createdEditor = factory(tui, editorTheme, keybindings);
+				if (typeof factory === "function") {
+					createdEditor = factory(tui, editorTheme, keybindings);
+					// Pi wires this callback onto custom editors after constructing them.
+					createdEditor.onExtensionShortcut = (data: string) => {
+						for (const [key, shortcut] of shortcuts) {
+							if (!matchesKey(data, key as any)) continue;
+							void shortcut.handler(ctx);
+							return true;
+						}
+						return false;
+					};
+				}
 			},
 			setStatus(key: string, text: string | undefined) { statuses.push([key, text]); },
 			notify(message: string, level: string) { notifications.push([message, level]); },
+			async select(title: string, options: string[]) {
+				selections.push({ title, options });
+				return selectedOption;
+			},
 			theme: {
 				bold: (text: string) => `**${text}**`,
 				fg: (_color: string, text: string) => text,
 			},
 		},
 	};
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	if (agentDir !== undefined) process.env.PI_CODING_AGENT_DIR = agentDir;
-	try {
-		planBuildModes(pi as any);
-	} finally {
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-	}
+	planBuildModes(pi as any);
 	return {
 		handlers,
 		ctx,
@@ -80,6 +117,11 @@ function createHarness(initialEditor?: unknown, agentDir?: string) {
 		notifications,
 		shortcuts,
 		registeredTools,
+		commands,
+		selections,
+		persisted,
+		selectOption(value: string | undefined) { selectedOption = value; },
+		nextPersist: () => new Promise<void>((resolve) => { resolvePersist = resolve; }),
 		editor: () => createdEditor,
 		setCurrentEditor(value: unknown) { currentEditor = value; },
 		decorateCurrentEditor() {
@@ -91,11 +133,40 @@ function createHarness(initialEditor?: unknown, agentDir?: string) {
 }
 
 async function start(harness: ReturnType<typeof createHarness>) {
+	runningHarnesses.add(harness);
 	await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
 }
 
 async function shutdown(harness: ReturnType<typeof createHarness>) {
 	await harness.handlers.get("session_shutdown")?.({ reason: "quit" }, harness.ctx);
+	runningHarnesses.delete(harness);
+}
+
+function writeConfig(value: unknown): void {
+	fs.writeFileSync(path.join(agentDir, SHORTCUT_CONFIG_FILE), JSON.stringify(value));
+}
+
+async function toggle(harness: ReturnType<typeof createHarness>, data: string, expected: string) {
+	const persisted = harness.nextPersist();
+	harness.editor().handleInput(data);
+	await persisted;
+	assert.equal(harness.persisted.at(-1).selectedMode, expected);
+}
+
+async function completeFile(harness: ReturnType<typeof createHarness>) {
+	fs.writeFileSync(path.join(agentDir, "README.md"), "");
+	fs.writeFileSync(path.join(agentDir, "README.txt"), "");
+	const editor = harness.editor();
+	editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], agentDir));
+	editor.setText("Review READ");
+	assert.equal(editor.isShowingAutocomplete(), false);
+	editor.handleInput("\t");
+	await editor.autocompleteRequestTask;
+	assert.equal(editor.isShowingAutocomplete(), true, "Tab must request file suggestions from a closed menu");
+	editor.handleInput("\t");
+	assert.match(editor.getText(), /^Review README\.(md|txt)\s*$/);
+	assert.equal(editor.isShowingAutocomplete(), false);
+	assert.equal(harness.persisted.at(-1).selectedMode, "build");
 }
 
 test("registers default Alt+M without taking Pi's Shift+Tab thinking shortcut", () => {
@@ -105,20 +176,101 @@ test("registers default Alt+M without taking Pi's Shift+Tab thinking shortcut", 
 	assert.equal(harness.shortcuts.has("shift+tab"), false);
 });
 
-test("leaves bare Tab to Pi's custom-editor handling by default", async () => {
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-plan-build-ui-"));
-	try {
-		const harness = createHarness(undefined, dir);
-		await start(harness);
-		const editor = harness.editor();
-		assert.ok(editor, "Pi Plan Build should install its custom editor");
+test("default Tab and Alt+M toggle modes while an open menu retains completion", { timeout: 5000 }, async () => {
+	const harness = createHarness();
+	await start(harness);
+	await toggle(harness, "\t", "plan");
+	await toggle(harness, "\x1bm", "build");
 
-		editor.handleInput("\t");
-		await new Promise((resolve) => setImmediate(resolve));
-		assert.match(editor.render(120).join("\n"), /\*\*build\*\*/);
-	} finally {
-		fs.rmSync(dir, { recursive: true, force: true });
-	}
+	const editor = harness.editor();
+	editor.setAutocompleteProvider(new CombinedAutocompleteProvider([{ name: "plan" }, { name: "plant" }], agentDir));
+	editor.handleInput("/");
+	await editor.autocompleteRequestTask;
+	assert.equal(editor.isShowingAutocomplete(), true);
+	editor.handleInput("\t");
+	assert.match(editor.getText(), /^\/plan\s*$/);
+	assert.equal(editor.isShowingAutocomplete(), false);
+	assert.equal(harness.persisted.at(-1).selectedMode, "build");
+});
+
+test("Alt+M only restores Tab-triggered file completion", { timeout: 5000 }, async () => {
+	writeConfig({ shortcuts: { toggleModeInEditor: [] } });
+	const harness = createHarness();
+	await start(harness);
+	await completeFile(harness);
+	await toggle(harness, "\x1bm", "plan");
+});
+
+test("custom global and editor shortcuts dispatch, while old bindings are absent", { timeout: 5000 }, async () => {
+	writeConfig({ shortcuts: { toggleMode: "ctrl+alt+m", toggleModeInEditor: ["f6"] } });
+	const harness = createHarness();
+	await start(harness);
+	assert.deepEqual([...harness.shortcuts.keys()], ["ctrl+alt+m"]);
+	await toggle(harness, "\x1b\r", "plan");
+	await toggle(harness, "\x1b[17~", "build");
+	await completeFile(harness);
+});
+
+test("disabled shortcuts register nothing and leave Tab completion intact", async () => {
+	writeConfig({ shortcuts: { toggleMode: [], toggleModeInEditor: [] } });
+	const harness = createHarness();
+	await start(harness);
+	assert.equal(harness.shortcuts.size, 0);
+	await completeFile(harness);
+});
+
+test("global Tab is rejected with editor-only guidance and autocomplete remains usable", async () => {
+	writeConfig({ shortcuts: { toggleMode: "tab", toggleModeInEditor: [] } });
+	const harness = createHarness();
+	await start(harness);
+	assert.deepEqual([...harness.shortcuts.keys()], ["alt+m"]);
+	assert.match(harness.notifications[0]![0], /put tab in shortcuts\.toggleModeInEditor/);
+	await completeFile(harness);
+});
+
+test("settings save the selected preset, retain active bindings until reload, and reload correctly", async () => {
+	const harness = createHarness();
+	await start(harness);
+	harness.selectOption("Alt+M only");
+	await harness.commands.get("plan-settings").handler("", harness.ctx);
+	assert.match(harness.selections[0]!.title, /active: Tab \+ Alt\+M/);
+	assert.deepEqual(harness.selections[0]!.options, ["Tab + Alt+M", "Alt+M only", "Disabled", "Custom (edit config file)"]);
+	assert.match(harness.notifications.at(-1)![0], /Saved Alt\+M only.*\/reload/);
+	assert.equal(harness.editor().matchesModeToggle("\t"), true);
+	await shutdown(harness);
+
+	const reloaded = createHarness();
+	await start(reloaded);
+	await completeFile(reloaded);
+	reloaded.selectOption("Disabled");
+	await reloaded.commands.get("plan-settings").handler("", reloaded.ctx);
+	assert.match(reloaded.selections[0]!.title, /active: Alt\+M only/);
+	assert.deepEqual(loadShortcutConfig(agentDir).config, { toggleMode: [], toggleModeInEditor: [] });
+});
+
+test("settings cancellation and custom guidance do not create or overwrite configuration", async () => {
+	const harness = createHarness();
+	const command = harness.commands.get("plan-settings");
+	await command.handler("", harness.ctx);
+	assert.equal(fs.existsSync(path.join(agentDir, SHORTCUT_CONFIG_FILE)), false);
+	writeConfig({ shortcuts: { toggleMode: "f6", toggleModeInEditor: [] }, unrelated: true });
+	const before = fs.readFileSync(path.join(agentDir, SHORTCUT_CONFIG_FILE), "utf8");
+	harness.selectOption("Custom (edit config file)");
+	await command.handler("", harness.ctx);
+	assert.ok(harness.notifications.at(-1)![0].includes(path.join(agentDir, SHORTCUT_CONFIG_FILE)));
+	assert.match(harness.notifications.at(-1)![0], /toggleModeInEditor.*file completion/);
+	assert.equal(fs.readFileSync(path.join(agentDir, SHORTCUT_CONFIG_FILE), "utf8"), before);
+});
+
+test("settings report a failed save without overwriting malformed JSON", async () => {
+	const configPath = path.join(agentDir, SHORTCUT_CONFIG_FILE);
+	fs.writeFileSync(configPath, "{");
+	const harness = createHarness();
+	harness.selectOption("Alt+M only");
+	await harness.commands.get("plan-settings").handler("", harness.ctx);
+	assert.equal(harness.notifications.at(-1)![1], "error");
+	assert.match(harness.notifications.at(-1)![0], /Could not save/);
+	assert.equal(fs.readFileSync(configPath, "utf8"), "{");
 });
 
 test("exposes plan_exit in the textual tool inventory metadata", () => {


### PR DESCRIPTION
## Summary
- Preserve **Tab + Alt+M** defaults: Tab switches modes with the composer autocomplete menu closed and accepts a suggestion with it open.
- Add `/plan-settings` with Tab + Alt+M, Alt+M only, Disabled, and custom-file guidance. Presets and manual custom bindings share `pi-plan-build.json`; `/reload` applies changes.
- Preserve unrelated configuration when saving, refuse malformed JSON, and atomically replace the configuration file.
- Reject global bare Tab and known unsupported matcher forms; document autocomplete tradeoffs and terminal limitations.

## Attribution
Thanks @VincentFF for reporting #4 and implementing configurable shortcuts in #3! This PR builds on your work and includes your original commit with its authorship preserved, followed by the settings/defaults/validation/testing adjustments. Feedback welcome.

Supersedes #3.
Fixes #4.

## Verification
- Passed: `node --experimental-strip-types --test shortcut-config.test.ts ui-compat.test.ts` — all 20 tests.
- Behavioral coverage includes default mode toggling, open-menu completion, closed-menu file completion with Alt+M only, custom global/editor dispatch, disabled shortcuts, settings persistence/reload, and malformed-file protection.
- Reviewed README configuration examples and package runtime/test-file entries; `git diff --check` passed.
- No full-suite, build, or packaging runs. Terminal-specific reporting of advanced custom keys was not manually verified.

No version bump or release is included.