### PR TITLE
feat: add configurable default Plan/Build startup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ One plan stays current through discussion, mode changes, and revisions. Complete
 | `Alt+M` | Toggle Plan/Build globally |
 | `Tab` | Toggle in the custom composer when autocomplete is closed; accept a suggestion when open |
 | `/plan` / `/build` | Select a mode |
-| `pi --plan` | Start in Plan |
+| `pi --plan` | Start in Plan for one run |
+| `pi --build` | Start in Build for one run |
 | `/plan new` | Start a plan when none is unfinished |
 | `/plan list` | Show the current plan's brief status |
 | `/plan show` | Read the current plan, progress, and outstanding validation |
@@ -51,7 +52,7 @@ One plan stays current through discussion, mode changes, and revisions. Complete
 | `/plan done` | Explicitly mark work complete in Build |
 | `/plan abandon` | Confirm abandonment without deleting the plan file |
 | `/build-fresh` | Retry a pending approved clean-session handoff |
-| `/plan-settings` | Configure shortcuts, titles, and per-mode model/thinking memory |
+| `/plan-settings` | Configure the default mode, shortcuts, titles, and per-mode model/thinking memory |
 
 Lifecycle and inspection commands require an idle agent. `/plan show` and `/plan history` do not require a model turn or start implementation.
 
@@ -61,6 +62,7 @@ Open `/plan-settings`:
 
 | Setting | Default | Behavior |
 | --- | --- | --- |
+| Default mode | Build | Startup mode for new sessions; the current session is unchanged |
 | Shortcuts | Tab + Alt+M | Open its submenu to choose Alt+M only, disable shortcuts, or configure custom keys; reload to apply |
 | Plan title | Off | Show the current task's title in the composer; applies immediately |
 | Per-mode model/thinking | Off | Remember separate Plan and Build selections; applies immediately |
@@ -107,7 +109,7 @@ The optional sidebar needs fullscreen TUI and at least **132 columns**. Step exe
 ## Documentation
 
 - [Workflow](docs/workflow.md): task boundaries, approval, clean sessions, completion, validation, and step execution.
-- [Settings](docs/settings.md): shortcuts, titles, and remembered model/thinking selections.
+- [Settings](docs/settings.md): default startup mode, shortcuts, titles, and remembered model/thinking selections.
 - [Internals](docs/internals.md): persistence, branch/fork handling, context, permission limits, and UI compatibility.
 - [Development](docs/development.md): local setup, tests, and release procedures.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,6 +2,27 @@
 
 [← README](../README.md)
 
+## Default startup mode
+
+Build is the default startup mode for new sessions. To start new sessions in Plan instead, choose **Default mode → Plan** in `/plan-settings`, or set `defaultMode` directly:
+
+```json
+{
+  "defaultMode": "plan"
+}
+```
+
+Only `"build"` and `"plan"` are accepted; any other value warns and falls back to Build. **Default mode** applies to sessions that have no mode recorded on their branch, so it takes effect immediately for the next session without `/reload` and never changes the current session's mode. Override it for a single run with `pi --plan` or `pi --build`.
+
+Startup mode resolves in this order:
+
+1. The mode recorded on the session branch.
+2. The `--plan` / `--build` CLI flag (`--plan` wins if both are passed).
+3. The `defaultMode` setting.
+4. Build.
+
+Restoring or forking a session therefore keeps its recorded mode, and `/reload` is only needed after editing the file by hand.
+
 ## Per-mode model and thinking selection
 
 In `/plan-settings`, choose **Per-mode model/thinking → On** to remember separate Plan and Build selections. This is **off by default**. Continue using Pi's normal model picker and thinking controls in each mode; switching modes restores that mode's last pair.
@@ -22,7 +43,7 @@ Manual mode changes during a run defer automatic model switching until that run 
 
 ## Shortcut configuration
 
-`/plan-settings` groups **Tab + Alt+M**, **Alt+M only**, **Disabled**, and **Custom (edit config file)** under the **Shortcuts** submenu. The main menu also offers **Plan title** and **Per-mode model/thinking**. Saving preserves unrelated settings; cancellation changes nothing. Malformed JSON is never overwritten. Shortcut changes require `/reload`; title and per-mode selection toggles apply immediately. Direct file edits require `/reload`.
+`/plan-settings` groups **Tab + Alt+M**, **Alt+M only**, **Disabled**, and **Custom (edit config file)** under the **Shortcuts** submenu. The main menu also offers **Default mode**, **Plan title**, and **Per-mode model/thinking**. Saving preserves unrelated settings; cancellation changes nothing. Malformed JSON is never overwritten. Shortcut changes require `/reload`; default mode, title, and per-mode selection changes apply without reloading. Direct file edits require `/reload`.
 
 Pi Plan Build reads `~/.pi/agent/pi-plan-build.json` (or `$PI_CODING_AGENT_DIR/pi-plan-build.json`):
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-1. Start in **Build** for ordinary discussion and coding. Small fixes need no plan.
+1. Start in **Build**, or in your configured [**Default mode**](settings.md#default-startup-mode), for ordinary discussion and coding. Small fixes need no plan.
 2. Select **Plan** with `/plan`, `Alt+M`, or the default editor `Tab` shortcut. This changes permissions, **not task selection**. Plan entry is user-controlled: the agent cannot auto-route a Build request into Plan, so a planning request made in Build requires you to switch modes. Discuss and research read-only; no Markdown is written merely by entering Plan.
 3. When you request a planning deliverable or accept a concrete proposed change during planning, the agent creates the current task; `/plan new` is the manual equivalent. It waits for the returned canonical path, completes necessary read-only investigation, saves the plan, and calls `plan_exit` for review and implementation approval. Accepting scope does not authorize implementation; informational agreement alone creates no task. You need not say “make a plan” again or switch manually to Build to get a plan written.
 4. Approve implementation **here**, in a **clean linked session**, or **step by step** (experimental; sidebar optional). Staying in Plan—or Escape—stops the run and waits for your next message.

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { pendingOrError, resultText, renderStepResult, statusCall, noticeTracker
 import { buildPlanContext, isObsoletePlanContext, TASK_CONTEXT_TYPE, RECONCILIATION_CONTEXT_TYPE } from "./plan-context.ts";
 import { PlanState, restoreCollection, allocationHighWater, latestPlanState, STATE_VERSION, STATE_TYPE, LEGACY_STATE_TYPE, type StoredState, type LegacyState } from "./plan-state.ts";
 import { registerQuestionTool } from "./question-ui.ts";
-import { loadShortcutConfig, saveShortcutPreset, saveShowPlanTitle, SHORTCUT_PRESETS, shortcutPresetLabel } from "./shortcut-config.ts";
+import { loadShortcutConfig, saveDefaultMode, saveShortcutPreset, saveShowPlanTitle, SHORTCUT_PRESETS, shortcutPresetLabel } from "./shortcut-config.ts";
 import {
 	PLAN_EXIT_DESCRIPTION,
 	PLAN_STEP_COMPLETE_DESCRIPTION,
@@ -89,9 +89,10 @@ function shorten(filePath: string, cwd: string): string {
 
 export default function planBuildModes(pi: ExtensionAPI): void {
 	const shortcutAgentDir = getAgentDir();
-	const { config: shortcutConfig, showPlanTitle, path: shortcutConfigPath, warning: shortcutConfigWarning } = loadShortcutConfig(shortcutAgentDir);
+	const { config: shortcutConfig, showPlanTitle, defaultMode: configuredDefaultMode, path: shortcutConfigPath, warning: shortcutConfigWarning } = loadShortcutConfig(shortcutAgentDir);
 	let shortcutConfigWarningShown = false;
 	let selectedMode: Mode = "build";
+	let defaultMode: Mode = configuredDefaultMode;
 	let runMode: Mode | undefined;
 	let pendingMode: Mode | undefined;
 	let modeTransition = 0;
@@ -134,6 +135,12 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 
 	pi.registerFlag("plan", {
 		description: "Start in Plan mode",
+		type: "boolean",
+		default: false,
+	});
+
+	pi.registerFlag("build", {
+		description: "Start in Build mode",
 		type: "boolean",
 		default: false,
 	});
@@ -459,10 +466,24 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 			if (!ctx.hasUI) return;
 			const customOption = "Custom (edit config file)";
 			const shortcutOption = `Shortcuts (active: ${shortcutPresetLabel(shortcutConfig)})`;
+			const defaultModeOption = `Default mode (active: ${defaultMode})`;
 			const modelOption = `Per-mode model/thinking (active: ${modeSelections.enabled ? "on" : "off"})`;
 			const titleOption = `Plan title (active: ${composerSettings.showPlanTitle ? "on" : "off"})`;
-			const selected = await ctx.ui.select("Plan/Build settings", [shortcutOption, titleOption, modelOption]);
+			const selected = await ctx.ui.select("Plan/Build settings", [defaultModeOption, shortcutOption, titleOption, modelOption]);
 			if (!selected) return;
+			if (selected === defaultModeOption) {
+				const choice = await ctx.ui.select("Default mode for new sessions", ["Build (default)", "Plan"]);
+				if (!choice) return;
+				try {
+					const mode: Mode = choice === "Plan" ? "plan" : "build";
+					saveDefaultMode(shortcutAgentDir, mode);
+					defaultMode = mode;
+					ctx.ui.notify(`New sessions start in ${mode === "plan" ? "Plan" : "Build"} mode. The current session is unchanged.`, "info");
+				} catch (error) {
+					ctx.ui.notify(`Could not save ${shortcutConfigPath}: ${error instanceof Error ? error.message : String(error)}`, "error");
+				}
+				return;
+			}
 			if (selected === modelOption) {
 				if (!ctx.isIdle() || pendingMode !== undefined) { ctx.ui.notify("Wait for the agent and mode switch to finish before changing model routing.", "warning"); return; }
 				const choice = await ctx.ui.select("Remember separate Plan and Build model/thinking selections", ["Off (default)", "On"]);
@@ -1190,7 +1211,9 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 		const decoded = decodeModeState(raw);
 		pendingFreshAnnouncement = raw?.pendingFreshAnnouncement === true;
 		pendingValidationNotice = undefined;
-		selectedMode = decoded?.selectedMode ?? (pi.getFlag("plan") === true ? "plan" : "build");
+		const flagMode: Mode | undefined = pi.getFlag("plan") === true ? "plan" : pi.getFlag("build") === true ? "build" : undefined;
+		// Startup mode priority: session branch record > CLI flag (--plan / --build) > defaultMode setting > Build.
+		selectedMode = decoded?.selectedMode ?? flagMode ?? defaultMode ?? "build";
 		restoreUserMessageRails(ctx.sessionManager.getBranch());
 		toolsBeforeModes = Array.isArray(raw?.toolsBeforeModes)
 			? raw.toolsBeforeModes.filter((name): name is string => typeof name === "string" && !MANAGED_TOOLS.has(name))

--- a/plan-lifecycle.test.ts
+++ b/plan-lifecycle.test.ts
@@ -20,6 +20,8 @@ function harness(dir: string, entries: any[] = [], sessionId = "session") {
 	const tools = new Map<string, any>();
 	const entryRenderers = new Map<string, any>();
 	const messageRenderers = new Map<string, any>();
+	const flags = new Map<string, any>();
+	const flagValues = new Map<string, boolean>();
 	let active = ["read", "write", "edit", "bash"];
 	let idle = true;
 	const events: any[] = [];
@@ -32,10 +34,10 @@ function harness(dir: string, entries: any[] = [], sessionId = "session") {
 		on,
 		registerCommand: (name: string, command: any) => commands.set(name, command),
 		registerTool: (tool: any) => tools.set(tool.name, tool),
-		registerShortcut() {}, registerFlag() {},
+		registerShortcut() {}, registerFlag: (name: string, flag: any) => flags.set(name, flag),
 		registerEntryRenderer: (type: string, renderer: any) => entryRenderers.set(type, renderer),
 		registerMessageRenderer: (type: string, renderer: any) => messageRenderers.set(type, renderer),
-		getFlag: () => false,
+		getFlag: (name: string) => flagValues.get(name) === true,
 		getActiveTools: () => active,
 		setActiveTools: (next: string[]) => { events.push({ kind: "tools" }); active = next; },
 		appendEntry: (customType: string, data: any) => {
@@ -74,7 +76,8 @@ function harness(dir: string, entries: any[] = [], sessionId = "session") {
 		return collection?.records.find((r: any) => r.plan.sequence === collection.attached) ?? collection?.records.at(-1);
 	}
 	return {
-		ctx, pi, events, commands, tools, entryRenderers, messageRenderers,
+		ctx, pi, events, commands, tools, entryRenderers, messageRenderers, flags,
+		setFlag: (name: string, value: boolean) => { flagValues.set(name, value); },
 		entries, active: () => active, setIdle: (value: boolean) => { idle = value; },
 		event: emit,
 		prompt: async (text: string) => {
@@ -142,6 +145,75 @@ test("per-mode settings toggle immediately and cancellation preserves the file",
 	} finally { fs.rmSync(dir, { recursive: true, force: true }); if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = previous; }
 });
 
+test("startup mode follows the session record, then the CLI flag, then defaultMode", async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "plan-default-mode-startup-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	// session_start applies the startup mode to tool routing, which is observable without persisting a record.
+	const startedInPlan = (h: ReturnType<typeof harness>) => h.active().includes("plan_exit") && !h.active().includes("plan_enter");
+	try {
+		fs.writeFileSync(path.join(dir, "pi-plan-build.json"), JSON.stringify({ defaultMode: "plan" }));
+		const configured = harness(dir);
+		await configured.event("session_start", { reason: "startup" });
+		assert.ok(startedInPlan(configured), "a new session must honor defaultMode");
+		assert.deepEqual(configured.flags.get("build"), { description: "Start in Build mode", type: "boolean", default: false });
+		await configured.event("session_shutdown");
+
+		const single = harness(dir);
+		single.setFlag("plan", true);
+		await single.event("session_start", { reason: "startup" });
+		assert.ok(startedInPlan(single), "--plan must still start in Plan");
+		await single.event("session_shutdown");
+
+		const override = harness(dir);
+		override.setFlag("build", true);
+		await override.event("session_start", { reason: "startup" });
+		assert.ok(!startedInPlan(override), "--build must override defaultMode plan for one run");
+		await override.event("session_shutdown");
+
+		const both = harness(dir);
+		both.setFlag("plan", true);
+		both.setFlag("build", true);
+		await both.event("session_start", { reason: "startup" });
+		assert.ok(startedInPlan(both), "--plan wins when both flags are set");
+		await both.event("session_shutdown");
+
+		const recorded = harness(dir, [{ type: "custom", customType: "pi-plan-build-state", data: { version: STATE_VERSION, selectedMode: "build", collection: { records: [], attached: null, counter: 0 } } }]);
+		await recorded.event("session_start", { reason: "resume" });
+		assert.ok(!startedInPlan(recorded), "the session branch record must win over defaultMode");
+		assert.equal(recorded.state().selectedMode, "build");
+		await recorded.event("session_shutdown");
+
+		fs.rmSync(path.join(dir, "pi-plan-build.json"));
+		const fallback = harness(dir);
+		await fallback.event("session_start", { reason: "startup" });
+		assert.ok(!startedInPlan(fallback), "no record, no flag, and no setting falls back to Build");
+		await fallback.event("session_shutdown");
+	} finally { fs.rmSync(dir, { recursive: true, force: true }); if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = previous; }
+});
+
+test("/plan-settings saves the default startup mode and preserves unrelated settings", async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "plan-default-mode-settings-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	try {
+		const file = path.join(dir, "pi-plan-build.json");
+		fs.writeFileSync(file, JSON.stringify({ showPlanTitle: true, shortcuts: { toggleMode: ["alt+m"], future: "value" } }));
+		const h = harness(dir);
+		await h.event("session_start", { reason: "startup" });
+		let answers: any[] = ["Default mode (active: build)", "Plan"];
+		h.ctx.ui.select = async () => answers.shift();
+		await h.commands.get("plan-settings").handler("", h.ctx);
+		const saved = JSON.parse(fs.readFileSync(file, "utf8"));
+		assert.equal(saved.defaultMode, "plan");
+		assert.equal(saved.showPlanTitle, true);
+		assert.deepEqual(saved.shortcuts, { toggleMode: ["alt+m"], future: "value" });
+		assert.ok(h.events.some((event) => event.kind === "notify" && event.text.includes("New sessions start in Plan mode")));
+		const before = fs.readFileSync(file, "utf8");
+		answers = ["Default mode (active: plan)", undefined];
+		await h.commands.get("plan-settings").handler("", h.ctx);
+		assert.equal(fs.readFileSync(file, "utf8"), before);
+		await h.event("session_shutdown");
+	} finally { fs.rmSync(dir, { recursive: true, force: true }); if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = previous; }
+});
 test("enabled per-mode selection defers manual routing until the active run settles", async () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "plan-mode-model-"));
 	const previous = process.env.PI_CODING_AGENT_DIR;

--- a/shortcut-config.test.ts
+++ b/shortcut-config.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { matchesKey } from "@earendil-works/pi-tui";
-import { isKeyId, loadShortcutConfig, parseShortcutConfig, saveShortcutPreset, saveShowPlanTitle, SHORTCUT_CONFIG_FILE, SHORTCUT_PRESETS, shortcutPresetLabel } from "./shortcut-config.ts";
+import { DEFAULT_MODE, isKeyId, loadShortcutConfig, parseShortcutConfig, saveDefaultMode, saveShortcutPreset, saveShowPlanTitle, SHORTCUT_CONFIG_FILE, SHORTCUT_PRESETS, shortcutPresetLabel } from "./shortcut-config.ts";
 
 test("plan title visibility defaults off and saves safely", () => {
 	assert.equal(parseShortcutConfig(undefined).showPlanTitle, false);
@@ -36,14 +36,48 @@ test("obsolete small-caps settings are ignored", () => {
 	for (const smallCapsPlanTitle of [true, false, "false"]) {
 		assert.deepEqual(parseShortcutConfig({ smallCapsPlanTitle, shortcuts: { toggleMode: [] } }), {
 			showPlanTitle: false,
+			defaultMode: "build",
 			config: { toggleMode: [], toggleModeInEditor: ["tab"] },
 		});
 	}
 });
 
+test("default startup mode parses, warns on invalid values, and saves without clobbering other settings", () => {
+	assert.equal(DEFAULT_MODE, "build");
+	assert.equal(parseShortcutConfig(undefined).defaultMode, "build");
+	for (const mode of ["build", "plan"] as const) {
+		const parsed = parseShortcutConfig({ defaultMode: mode });
+		assert.equal(parsed.defaultMode, mode);
+		assert.equal(parsed.warning, undefined);
+	}
+	for (const invalid of ["Plan", "remember", true, 1, null, [], {}]) {
+		const parsed = parseShortcutConfig({ defaultMode: invalid });
+		assert.equal(parsed.defaultMode, "build", `${JSON.stringify(invalid)} must fall back to build`);
+		assert.match(parsed.warning ?? "", /defaultMode must be "build" or "plan"/);
+	}
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "plan-default-mode-"));
+	try {
+		const file = path.join(dir, SHORTCUT_CONFIG_FILE);
+		fs.writeFileSync(file, JSON.stringify({ unrelated: 42, showPlanTitle: true, shortcuts: { toggleMode: ["alt+m"], future: "value" } }));
+		assert.equal(saveDefaultMode(dir, "plan"), file);
+		assert.equal(loadShortcutConfig(dir).defaultMode, "plan");
+		const saved = JSON.parse(fs.readFileSync(file, "utf8"));
+		assert.equal(saved.unrelated, 42);
+		assert.equal(saved.showPlanTitle, true);
+		assert.deepEqual(saved.shortcuts, { toggleMode: ["alt+m"], future: "value" });
+		assert.deepEqual(fs.readdirSync(dir), [SHORTCUT_CONFIG_FILE], "atomic save leaves no temporary file");
+		for (const malformed of ["{", "null", "[]", '{"shortcuts":[]}']) {
+			fs.writeFileSync(file, malformed);
+			assert.throws(() => saveDefaultMode(dir, "plan"));
+			assert.equal(fs.readFileSync(file, "utf8"), malformed);
+		}
+	} finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
 test("shortcut defaults preserve Tab and Alt+M", () => {
 	assert.deepEqual(parseShortcutConfig(undefined), {
 		showPlanTitle: false,
+		defaultMode: "build",
 		config: {
 			toggleMode: ["alt+m"],
 			toggleModeInEditor: ["tab"],
@@ -61,6 +95,7 @@ test("shortcut configuration accepts remapping and explicit disabling", () => {
 
 	assert.deepEqual(result, {
 		showPlanTitle: false,
+		defaultMode: "build",
 		config: {
 			toggleMode: ["ctrl+alt+m"],
 			toggleModeInEditor: ["ctrl+shift+m", "f6"],
@@ -145,6 +180,7 @@ test("shortcut configuration reads the Pi agent directory and fails safely", () 
 	try {
 		assert.deepEqual(loadShortcutConfig(dir), {
 			showPlanTitle: false,
+			defaultMode: "build",
 			config: { toggleMode: ["alt+m"], toggleModeInEditor: ["tab"] },
 			path: path.join(dir, SHORTCUT_CONFIG_FILE),
 		});

--- a/shortcut-config.ts
+++ b/shortcut-config.ts
@@ -2,8 +2,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { KeyId } from "@earendil-works/pi-tui";
+import type { Mode } from "./utils.ts";
 
 export const SHORTCUT_CONFIG_FILE = "pi-plan-build.json";
+
+export const DEFAULT_MODE: Mode = "build";
 
 const BASE_KEYS = new Set([
 	..."abcdefghijklmnopqrstuvwxyz",
@@ -21,6 +24,7 @@ export interface ShortcutConfig {
 
 export interface LoadedShortcutConfig {
 	showPlanTitle: boolean;
+	defaultMode: Mode;
 	config: ShortcutConfig;
 	path: string;
 	warning?: string;
@@ -122,11 +126,18 @@ function parseShortcuts(value: unknown): {
 	};
 }
 
+function parseDefaultMode(value: unknown): { defaultMode: Mode; warning?: string } {
+	if (value === undefined) return { defaultMode: DEFAULT_MODE };
+	if (value === "build" || value === "plan") return { defaultMode: value };
+	return { defaultMode: DEFAULT_MODE, warning: 'defaultMode must be "build" or "plan"' };
+}
+
 export function parseShortcutConfig(value: unknown): Omit<LoadedShortcutConfig, "path"> {
 	const parsed = parseShortcuts(value);
 	const preference = isObject(value) ? value.showPlanTitle : undefined;
-	const warning = [parsed.warning, preference !== undefined && typeof preference !== "boolean" ? "showPlanTitle must be a boolean" : undefined].filter(Boolean).join("; ");
-	return { ...parsed, showPlanTitle: preference === true, ...(warning ? { warning } : {}) };
+	const mode = isObject(value) ? parseDefaultMode(value.defaultMode) : { defaultMode: DEFAULT_MODE };
+	const warning = [parsed.warning, mode.warning, preference !== undefined && typeof preference !== "boolean" ? "showPlanTitle must be a boolean" : undefined].filter(Boolean).join("; ");
+	return { ...parsed, showPlanTitle: preference === true, defaultMode: mode.defaultMode, ...(warning ? { warning } : {}) };
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -141,6 +152,11 @@ export function saveShortcutPreset(agentDir: string, presetName: string): string
 
 export function saveShowPlanTitle(agentDir: string, enabled: boolean): string {
 	return saveSettings(agentDir, (document) => ({ ...document, showPlanTitle: enabled }));
+}
+
+export function saveDefaultMode(agentDir: string, mode: Mode): string {
+	if (mode !== "build" && mode !== "plan") throw new Error("The default mode must be build or plan");
+	return saveSettings(agentDir, (document) => ({ ...document, defaultMode: mode }));
 }
 
 export function saveSettings(agentDir: string, update: (document: Record<string, unknown>) => Record<string, unknown>): string {

--- a/ui-compat.test.ts
+++ b/ui-compat.test.ts
@@ -334,7 +334,7 @@ test("settings group shortcut presets in a submenu, retain active bindings until
 	harness.selectOptions("Shortcuts (active: Tab + Alt+M)", "Alt+M only");
 	await harness.commands.get("plan-settings").handler("", harness.ctx);
 	assert.equal(harness.selections[0]!.title, "Plan/Build settings");
-	assert.deepEqual(harness.selections[0]!.options, ["Shortcuts (active: Tab + Alt+M)", "Plan title (active: off)", "Per-mode model/thinking (active: off)"]);
+	assert.deepEqual(harness.selections[0]!.options, ["Default mode (active: build)", "Shortcuts (active: Tab + Alt+M)", "Plan title (active: off)", "Per-mode model/thinking (active: off)"]);
 	assert.match(harness.selections[1]!.title, /active: Tab \+ Alt\+M/);
 	assert.deepEqual(harness.selections[1]!.options, ["Tab + Alt+M", "Alt+M only", "Disabled", "Custom (edit config file)"]);
 	assert.match(harness.notifications.at(-1)![0], /Saved Alt\+M only.*\/reload/);


### PR DESCRIPTION
## What

New sessions always start in Build; the only way to override that was the one-shot `pi --plan` flag. This adds a persistent `defaultMode` setting plus the symmetric `--build` flag, so a Plan-first workflow no longer needs a flag on every launch.

## Startup priority (no behavior change for existing sessions)

```
session branch record   >   --plan / --build   >   defaultMode   >   Build
```

1. The mode recorded on the session branch
2. The `--plan` / `--build` CLI flag (`--plan` wins if both are passed)
3. The `defaultMode` setting
4. Build

Restoring or forking a session therefore keeps its recorded mode, and `--plan` keeps working exactly as before.

## The setting

```json
{
  "defaultMode": "plan"
}
```

- Only `"build"` and `"plan"` are accepted; any other value warns and falls back to Build, using the existing invalid-configuration notice.
- Saving preserves unrelated keys and never overwrites malformed JSON (same contract as the other settings).
- `/plan-settings → Default mode (active: build|plan)` saves it without `/reload`. It applies to **new** sessions only and never changes the current session's mode.
- No idle restriction is needed, since it does not alter the running mode.

Direct file edits still require `/reload`, consistent with the other settings.

## Changes

- `shortcut-config.ts` — `DEFAULT_MODE`, `defaultMode` in `LoadedShortcutConfig`/`parseShortcutConfig` (warn + fall back on invalid values), new `saveDefaultMode`. `Mode` is a type-only import from `utils.ts`, so there is no runtime cycle.
- `index.ts` — registers `--build`; holds a mutable `defaultMode`; replaces the hardcoded startup ternary with the four-tier chain in `session_start`; adds the `Default mode` entry to `/plan-settings` with save + notify. `composerSettings` is deliberately untouched.
- `shortcut-config.test.ts` — updated the 4 existing `deepEqual` assertions for the new field; new cases for default value, invalid values, save round-trip preserving `showPlanTitle`/`shortcuts`/unknown keys, no leftover temp file, and malformed-file refusal leaving bytes untouched.
- `plan-lifecycle.test.ts` — harness now records `registerFlag` and takes an injectable `getFlag`/`setFlag`; new cases cover the startup priority chain (including `--plan` winning over `--build`) and the `/plan-settings` save/cancel path.
- `ui-compat.test.ts` — menu option list updated for the new first entry.
- Docs — README commands/settings tables, a "Default startup mode" section in `docs/settings.md` with the JSON example and priority list, and one line in `docs/workflow.md`.

## Verification

- `npm test` — 131/131 pass.
- `npm pack --dry-run` — tarball manifest unchanged (25 files), i.e. no files added or dropped.
- Negative control — the new startup test fails against the previous hardcoded expression.

No version bump and no behavior change for anyone who does not set `defaultMode`.
