### PR TITLE
Wrap the step-by-step plan panel in a contained ScrollView for independent wheel scrolling

### DIFF
--- a/composer.ts
+++ b/composer.ts
@@ -1,6 +1,6 @@
 import { CustomEditor, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { HStack, matchesKey, ScrollView, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
-import { PlanPanel } from "./plan-panel.ts";
+import { HStack, matchesKey, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
+import { PlanPanel, ContainedScrollView } from "./plan-panel.ts";
 import type { PlanExecutionState } from "./plan-execution.ts";
 import { formatModeRail, formatModeMetadata, formatModeTopBorder, nextMode, ownsUiSlot, renderModeComposer, shouldReduceOptionalUi, type Mode } from "./utils.ts";
 
@@ -71,8 +71,8 @@ export function createComposer(
 		if (!panelRoot) {
 			const layoutToken = { enabled: true };
 			token = layoutToken;
-			// ponytail: wheel-scroll isolation and a scrollbar come free from ScrollView; "contain" never chains to the chat
-			const scroller = new ScrollView(panel, { overscroll: "contain", scrollbar: "auto" });
+			// ponytail: ContainedScrollView swallows leftover wheel lines so scrolling never chains to the chat
+			const scroller = new ContainedScrollView(panel, { overscroll: "contain", scrollbar: "auto" });
 			panelRoot = new HStack([
 				{ component: originalRoot, basis: 0, grow: 1, shrink: 1, minSize: 58 },
 				{ component: scroller, basis: PANEL_WIDTH, grow: 0, shrink: 0, minSize: PANEL_WIDTH, maxSize: PANEL_WIDTH,

--- a/composer.ts
+++ b/composer.ts
@@ -1,5 +1,5 @@
 import { CustomEditor, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { HStack, matchesKey, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
+import { HStack, matchesKey, ScrollView, truncateToWidth, visibleWidth, isViewportTUI, type Component, type TUI, type ViewportTUI } from "@earendil-works/pi-tui";
 import { PlanPanel } from "./plan-panel.ts";
 import type { PlanExecutionState } from "./plan-execution.ts";
 import { formatModeRail, formatModeMetadata, formatModeTopBorder, nextMode, ownsUiSlot, renderModeComposer, shouldReduceOptionalUi, type Mode } from "./utils.ts";
@@ -71,9 +71,11 @@ export function createComposer(
 		if (!panelRoot) {
 			const layoutToken = { enabled: true };
 			token = layoutToken;
+			// ponytail: wheel-scroll isolation and a scrollbar come free from ScrollView; "contain" never chains to the chat
+			const scroller = new ScrollView(panel, { overscroll: "contain", scrollbar: "auto" });
 			panelRoot = new HStack([
 				{ component: originalRoot, basis: 0, grow: 1, shrink: 1, minSize: 58 },
-				{ component: panel, basis: PANEL_WIDTH, grow: 0, shrink: 0, minSize: PANEL_WIDTH, maxSize: PANEL_WIDTH,
+				{ component: scroller, basis: PANEL_WIDTH, grow: 0, shrink: 0, minSize: PANEL_WIDTH, maxSize: PANEL_WIDTH,
 					visible: (viewport) => layoutToken.enabled && !reduced && !!view().execution && view().execution?.panelVisible !== false && viewport.width >= PANEL_MIN_TERMINAL_WIDTH },
 			]);
 			tui.setLayoutRoot?.(panelRoot);

--- a/plan-panel.test.ts
+++ b/plan-panel.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { ScrollView, visibleWidth, type Component } from "@earendil-works/pi-tui";
 import { completePlanStep, createPlanExecution, startPlanStep } from "./plan-execution.ts";
-import { PlanPanel } from "./plan-panel.ts";
+import { ContainedScrollView, PlanPanel } from "./plan-panel.ts";
 
 const theme = {
 	fg(_color: string, text: string) { return text; },
@@ -15,6 +15,20 @@ const panelText = (lines: string[]) => lines
 	.map((line) => line.slice(2, -2).trim())
 	.filter(Boolean)
 	.join(" ");
+
+test("contained scroller swallows leftover wheel lines so the chat never chains", () => {
+	const child = { render: () => ["a", "b", "c"], invalidate: () => {} } as unknown as Component;
+	const requestRender = () => {};
+	const plain = new ScrollView(child);
+	plain.updateLayout(3, 2, requestRender);
+	assert.equal(plain.scrollBy(5), 4, "a plain ScrollView reports the unconsumed remainder");
+	const contained = new ContainedScrollView(child, { overscroll: "contain" });
+	contained.updateLayout(3, 2, requestRender);
+	contained.scrollBy(5);
+	assert.equal(contained.scrollTop, 1, "the scroller itself still moves and clamps");
+	assert.equal(contained.scrollBy(5), 0, "leftover wheel lines are consumed, so routeWheel cannot chain to the primary");
+	assert.equal(contained.scrollBy(-5), 0);
+});
 
 test("passive panel renders steps within its reserved width with fixed instructions", () => {
 	const panel = new PlanPanel(makeState(), theme);

--- a/plan-panel.ts
+++ b/plan-panel.ts
@@ -1,6 +1,20 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { ScrollView, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
 import type { PlanExecutionState } from "./plan-execution.ts";
+
+/**
+ * ScrollView whose wheel events never chain to the chat. pi-tui's routeWheel stops walking
+ * the hit ScrollViews when overscroll is "contain", but its primary fallback still forwards
+ * unconsumed wheel lines to the chat's ScrollView. Returning 0 from scrollBy marks every
+ * wheel as fully consumed, so that fallback never fires.
+ * ponytail: delete this class once pi-tui's routeWheel honors containment against the primary fallback.
+ */
+export class ContainedScrollView extends ScrollView {
+	override scrollBy(lines: number): number {
+		super.scrollBy(lines);
+		return 0;
+	}
+}
 
 const GLYPHS = {
 	pending: "○",


### PR DESCRIPTION
The step-by-step panel rendered every step unconditionally with no scroll state, so long plans were clipped and wheel events over the panel fell through to the chat's primary ScrollView. The panel is now wrapped in pi-tui's `ScrollView` (`overscroll: "contain"`, `scrollbar: "auto"`): wheel over the panel scrolls only the panel, a transient scrollbar appears, and viewport clamping comes from the existing layout engine. `composer.ts` only.
