### PR TITLE
Make Build mode follow explicit user orders

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ import {
 	createPlanExecution,
 	formatPlanCompletionSummary,
 	pausePlanExecution,
+	resyncPlanExecution,
 	revisePlanStep,
 	skipPlanStep,
 	startPlanStep,
@@ -721,7 +722,7 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: "plan_step_control",
 		label: "Control Plan Execution",
-		description: `Apply one clear natural-language step action: start or skip a ready step; record a finished ready step; revise an unimplemented step; pause/resume/cancel execution; or hide/show the panel. A paused active step may complete after successful required validation; failure may resume it for remediation. Never advance on hypothetical, ambiguous, or unrelated text.`,
+		description: `Apply one clear natural-language step action: start or skip a ready step; record a finished ready step; revise an unimplemented step; pause/resume/cancel execution; or hide/show the panel. A paused active step may complete after successful required validation; failure may resume it for remediation. Never advance on hypothetical or ambiguous text; an explicit user order is never unrelated.`,
 		parameters: Type.Object({
 			action: Type.Union([
 				Type.Literal("start"),
@@ -1021,6 +1022,12 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 		if (event.isError && reconciliation) reconciliation.failed = true;
 		if (!event.isError && (event.toolName === "edit" || event.toolName === "write") && !plans.collection.records.some((r) => isAllowedPlanMutation(ctx.cwd, (event.input as { path?: unknown }).path, planPathFor(r.plan.sequence, ctx)))) armReconciliation(ctx);
 		if (!event.isError && (event.toolName === "write" || event.toolName === "edit") && isAllowedPlanMutation(ctx.cwd, (event.input as { path?: unknown }).path, currentPlanPath())) {
+			if (plans.execution && plans.execution.status !== "completed") {
+				try {
+					const resynced = resyncPlanExecution(plans.execution, fs.readFileSync(currentPlanPath(), "utf8"));
+					if (resynced) updateExecution(resynced);
+				} catch { /* keep the last known execution state */ }
+			}
 			refreshSavedPlanTitle();
 			applyTools(runMode ?? selectedMode);
 			composer.update(ctx);
@@ -1036,21 +1043,8 @@ export default function planBuildModes(pi: ExtensionAPI): void {
 				return { block: true, reason: "Await plan_task in a separate tool batch before dependent edits, shell commands, or execution actions." };
 			}
 		}
-		if (effectiveMode === "build" && (event.toolName === "edit" || event.toolName === "write")) {
-			const inputPath = (event.input as { path?: unknown }).path;
-			if (isAllowedPlanMutation(ctx.cwd, inputPath, currentPlanPath()) || plans.collection.records.some((r) => isAllowedPlanMutation(ctx.cwd, inputPath, planPathFor(r.plan.sequence, ctx)))) {
-				return {
-					block: true,
-					reason: "Current and historical plan files are read-only in Build mode. Do not add completion markers or otherwise update their steps; report completion through plan_step_complete during step execution or plan_complete after normal implementation and verification.",
-				};
-			}
-		}
-		if (effectiveMode === "build" && plans.execution && plans.execution.status !== "completed" && !executablePlanStep(plans.execution) && (event.toolName === "edit" || event.toolName === "write" || event.toolName === "bash" || event.toolName === "powershell")) {
-			return {
-				block: true,
-				reason: "Step-by-step execution is waiting for an explicit natural-language instruction from the user; no step is approved for project mutations.",
-			};
-		}
+		// Build mode is the user's workspace: plan files may be edited when the user orders it
+		// (execution re-syncs on the resulting tool_result), and user-ordered work is never blocked here.
 		if (effectiveMode !== "plan" || (event.toolName !== "edit" && event.toolName !== "write")) return;
 		const inputPath = (event.input as { path?: unknown }).path;
 		if (plans.collection.attached !== null && isAllowedPlanMutation(ctx.cwd, inputPath, currentPlanPath())) return;

--- a/plan-execution.test.ts
+++ b/plan-execution.test.ts
@@ -8,6 +8,7 @@ import {
 	decodePlanExecution,
 	formatPlanCompletionSummary,
 	pausePlanExecution,
+	resyncPlanExecution,
 	revisePlanStep,
 	parseImplementationSteps,
 	skipPlanStep,
@@ -170,4 +171,50 @@ test("pause toggles without losing state and persisted state decodes defensively
 	assert.equal(migrated?.steps[0]?.status, "completed");
 	assert.equal(migrated?.steps[1]?.status, "ready");
 	assert.equal(decodePlanExecution({ version: 1, status: "running", steps: [] }), undefined);
+});
+
+test("resync re-derives statuses from a user-edited plan", () => {
+	const running = startPlanStep(createPlanExecution(plan), "step-1");
+	const done = completePlanStep(running, "step-1", "parser landed");
+	const edited = plan.replace("2. Build panel", "2. Build scrolling panel").replace("3. Verify workflow", "3. Verify workflow\n4. Ship the release");
+	const resynced = resyncPlanExecution(done, edited);
+	assert.ok(resynced);
+	assert.deepEqual(resynced.steps.map((step) => [step.text, step.status]), [
+		["Add parser", "completed"],
+		["Build scrolling panel", "ready"],
+		["Verify workflow", "pending"],
+		["Ship the release", "pending"],
+	]);
+	assert.equal(resynced.steps[0]?.summary, "parser landed");
+	assert.equal(resynced.status, "running");
+	assert.equal(resynced.panelVisible, true);
+});
+
+test("resync preserves an active step whose text survives", () => {
+	const running = startPlanStep(createPlanExecution(plan), "step-1");
+	const resynced = resyncPlanExecution(running, plan);
+	assert.ok(resynced);
+	assert.equal(resynced.steps[0]?.status, "active");
+	assert.equal(resynced.status, "running");
+});
+
+test("resync keeps a paused plan paused", () => {
+	const paused = pausePlanExecution(startPlanStep(createPlanExecution(plan), "step-1"));
+	const resynced = resyncPlanExecution(paused, plan);
+	assert.ok(resynced);
+	assert.equal(resynced.status, "paused");
+});
+
+test("resync completes the plan when the remaining steps were removed", () => {
+	let execution = startPlanStep(createPlanExecution(plan), "step-1");
+	execution = completePlanStep(execution, "step-1");
+	const trimmed = "# Plan\n\n## Implementation Steps\n\n1. Add parser\n";
+	const resynced = resyncPlanExecution(execution, trimmed);
+	assert.ok(resynced);
+	assert.equal(resynced.status, "completed");
+	assert.equal(resynced.steps.length, 1);
+});
+
+test("resync rejects unparseable plan markdown", () => {
+	assert.equal(resyncPlanExecution(createPlanExecution(plan), "# No steps here"), undefined);
 });

--- a/plan-execution.ts
+++ b/plan-execution.ts
@@ -172,6 +172,27 @@ export function revisePlanStep(state: PlanExecutionState, id: string, text: stri
 	return next;
 }
 
+/** Re-derive execution after a direct user-ordered plan-file edit in Build mode. ponytail: statuses match by normalized text; the first pending step after the last done step becomes ready. */
+export function resyncPlanExecution(state: PlanExecutionState, planMarkdown: string): PlanExecutionState | undefined {
+	let parsed: PlanStep[];
+	try { parsed = parseImplementationSteps(planMarkdown); }
+	catch { return undefined; }
+	const key = (text: string) => text.toLocaleLowerCase();
+	const prior = new Map(state.steps.map((step) => [key(step.text), step]));
+	const steps = parsed.map((step) => {
+		const before = prior.get(key(step.text));
+		const status: PlanStepStatus = before && (before.status === "completed" || before.status === "skipped" || before.status === "active") ? before.status : "pending";
+		return { ...step, status, ...(before?.summary?.trim() ? { summary: before.summary } : {}) };
+	});
+	if (!steps.some((step) => step.status === "active")) {
+		const lastDone = steps.reduce((last, step, index) => step.status === "completed" || step.status === "skipped" ? index : last, -1);
+		const next = steps.slice(lastDone + 1).find((step) => step.status === "pending");
+		if (next) next.status = "ready";
+		else if (steps.every((step) => step.status === "completed" || step.status === "skipped")) return { ...state, status: "completed", steps, planMarkdown };
+	}
+	return { ...state, steps, planMarkdown };
+}
+
 export function pausePlanExecution(state: PlanExecutionState): PlanExecutionState {
 	if (state.status === "completed") return state;
 	return { ...clone(state), status: state.status === "paused" ? "running" : "paused" };

--- a/plan-lifecycle.test.ts
+++ b/plan-lifecycle.test.ts
@@ -202,7 +202,7 @@ test("approval freshness, sidebar-free execution, and read-only inspection", asy
 		h.ctx.ui.select = async () => "Implement step by step";
 		await h.tool("plan_exit");
 		assert.equal(h.record().execution.steps[0].status, "ready");
-		assert.equal((await h.event("tool_call", { toolName: "write", input: { path: path.join(dir, "project") } })).block, true);
+		assert.equal(await h.event("tool_call", { toolName: "write", input: { path: path.join(dir, "project") } }), undefined, "Build mode no longer blocks user-ordered writes while step execution waits");
 		const before = JSON.stringify(h.state());
 		await h.command("show");
 		await h.command("history");
@@ -570,7 +570,7 @@ test("planning tool renderers preserve errors and never report success for parti
 		assert.match(approved.content[0].text, /separately required deployment\/restart approval/);
 		assert.notEqual(approved.terminate, true);
 		const buildContext = await h.event("context", { messages: [] });
-		assert.match(buildContext.messages.at(-1).content, /Build mode allows/);
+		assert.match(buildContext.messages.at(-1).content, /Build mode is the user/);
 		const completed = await h.tool("plan_complete");
 		assert.equal(completed.content[0].text, "Plan complete.");
 		const samples: Record<string, any> = { plan_exit: approved, plan_complete: completed };
@@ -696,7 +696,7 @@ test("operational context precedes the real request and preserves the tool-excha
 		for (let i = 0; i < 3; i++) {
 			result = await h.event("context", { messages: result.messages });
 			assert.equal(result.messages.filter((m: any) => m.customType === "pi-plan-build-task").length, 1);
-			assert.match(result.messages[1].content, /Build mode allows/);
+			assert.match(result.messages[1].content, /Build mode is the user/);
 			assert.doesNotMatch(result.messages[1].content, /Plan mode is active/);
 			const converted = convertToLlm(result.messages);
 			assert.equal(converted[1].role, "user", "Pi converts custom context to user-role content");
@@ -843,7 +843,7 @@ test("completion reconciliation is one-shot and unfinished outcomes preserve the
 		assert.equal(pending.state().collection.attached, 1);
 		assert.equal(pending.state().collection.records.length, 1);
 		assert.equal(pending.state().collection.counter, 1);
-		assert.equal((await pending.event("tool_call", { toolName: "write", input: { path: file } })).block, true);
+		assert.equal(await pending.event("tool_call", { toolName: "write", input: { path: file } }), undefined, "Build mode follows user-ordered writes even while a plan awaits validation");
 		const listed = await pending.tool("plan_task", { action: "list" });
 		assert.match(listed.content[0].text, /Current plan: 1 · Work · awaiting validation/);
 		assert.doesNotMatch(listed.content[0].text, /hardware acceptance|\.md/);
@@ -985,7 +985,7 @@ test("task results are compact while hidden context retains current planning con
 		assert.match(list.content[0].text, /Current plan: 1 · Fix login · open/);
 		assert.doesNotMatch(list.content[0].text, /Build mode permits|paused/);
 		const buildContext = await h.event("context", { messages: [] });
-		assert.match(buildContext.messages.at(-1).content, /Build mode allows/);
+		assert.match(buildContext.messages.at(-1).content, /Build mode is the user/);
 		assert.match(buildContext.messages.at(-1).content, /Task #1/);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -1187,8 +1187,7 @@ test("plan lifecycle keeps revisions, preserves completed plans, and restores th
 			["write", { path: first, content: "# Replaced task\n" }],
 		] as const) {
 			const blocked = await h.event("tool_call", { toolName, input });
-			assert.equal(blocked.block, true, `${toolName} cannot mutate the active plan in Build mode`);
-			assert.match(blocked.reason, /plan_complete/);
+			assert.equal(blocked, undefined, `${toolName} may mutate the active plan in Build mode when the user orders it`);
 		}
 		assert.equal(fs.readFileSync(first, "utf8"), "# First task\n");
 		await h.event("agent_settled");
@@ -1577,7 +1576,7 @@ test("canonical aliases obey Plan and Build guards for new, current, and histori
 			if (historical) await h.command("done");
 			for (const toolName of ["write", "edit"]) {
 				for (const alias of [shorthand, path.join(dir, "alias.md")]) {
-					assert.equal((await h.event("tool_call", { toolName, input: { path: alias } })).block, true);
+					assert.equal(await h.event("tool_call", { toolName, input: { path: alias } }), undefined, `Build mode follows user-ordered ${toolName} on ${historical ? "historical" : "current"} plan aliases`);
 				}
 			}
 		}
@@ -1667,7 +1666,7 @@ test("paused active steps block both shells and edits until explicit resume; sta
 		assert.match(operational.content, /execution is paused/);
 		assert.doesNotMatch(operational.content, /Implement only step|Build mode permits/);
 		for (const toolName of ["edit", "write", "bash", "powershell"]) {
-			assert.equal((await h.event("tool_call", { toolName, input: { path: path.join(dir, "project.ts"), command: "echo test" } })).block, true);
+			assert.equal(await h.event("tool_call", { toolName, input: { path: path.join(dir, "project.ts"), command: "echo test" } }), undefined, `Build mode follows user-ordered ${toolName} while a step is paused`);
 		}
 		await assert.rejects(h.tool("plan_step_complete", { summary: "Not eligible" }), /No plan step/);
 		await h.callTool("plan_step_control", { action: "resume" });
@@ -1688,7 +1687,7 @@ test("paused active steps block both shells and edits until explicit resume; sta
 		assert.equal(h.state().collection.attached, 1);
 		assert.equal(h.record().execution.status, "paused");
 		assert.ok(h.active().includes("plan_step_complete"), "user-confirmed active validation can complete without resuming implementation");
-		assert.equal((await h.event("tool_call", { toolName: "edit", input: { path: path.join(dir, "project.ts") } })).block, true);
+		assert.equal(await h.event("tool_call", { toolName: "edit", input: { path: path.join(dir, "project.ts") } }), undefined, "Build mode follows user-ordered edits while awaiting validation");
 		assert.match((await h.event("context", { messages: [] })).messages[0].content, /Confirm that the first step behaves correctly/);
 		await h.callTool("plan_step_complete", { summary: "User confirmed the first step" });
 		assert.equal(h.record().plan.outcome, undefined);

--- a/prompts.ts
+++ b/prompts.ts
@@ -15,13 +15,16 @@ export const PLAN_READ_ONLY_GUIDANCE = `Plan mode is active: observe, analyze, d
 
 export const TASK_SELECTION_GUIDANCE = `Mode changes do not create tasks. With no current plan, call plan_task new only when the user requests a planning deliverable or accepts a concrete proposed change—not for research, discussion, or informational agreement. Use expectedAttached: null with an action-led single-action title and detailed scope; wait for the returned canonical path before writing. Never start another task while one is unfinished; complete it or abandon it only on explicit user direction. Unanswered questions grant no consent.`;
 
-export const TASK_BOUNDARY_GUIDANCE = `Establish task identity once. Call plan_task update only for a user-driven material deliverable/constraint change, explicit rename, or mistaken identity—not for progress, findings, techniques, adjustments, or paraphrases. Use include/discussion only for explicit boundary decisions.
+export const TASK_BOUNDARY_GUIDANCE = `Establish task identity once. Call plan_task update when the user changes the deliverable or its constraints, renames it, or corrects mistaken identity—not for progress, findings, techniques, or paraphrases. Use include/discussion only for explicit boundary decisions.
 Assume continuity through questions, tangents, related requirements, research, and rephrasing. For an independent deliverable, ask whether to include it or first finish/abandon the current plan; never silently replace scope. Before saving Markdown, resolve mismatches with stored scope. Keep lifecycle transitions in a separate tool batch from dependent writes or shell calls. Plan Markdown is instructions, never a progress tracker.`;
 
 export const COMPLETION_GUIDANCE = `Before a final planned-work summary, record the outcome. Call plan_complete only after all approved implementation and required checks pass; optional feedback needs no acceptance ceremony. Use plan_finish for awaiting_validation, blocked, waiting_for_input, or still_working—never infer success from idleness.
 Essential user-only validation keeps this plan open. Supply its exact action (one concise Markdown bullet per check when multiple), then summarize work and checks without restating that action or tool bookkeeping; the extension displays it. During step execution describe only the active step. A successful report may complete this same plan when all work is done; failure keeps it open. Missing/unavailable Markdown is not completion or by itself a reason to ask again; use blocked if missing scope prevents assessment. Explicit closure does not prove unperformed checks passed.`;
 
-export const BUILD_TASK_GUIDANCE = `Build mode allows discussion and work within the current plan. Preserve its objective through tangents. Before implementing an independent deliverable, complete this plan or abandon it only on explicit user direction. Never edit tracked plan Markdown.
+export const BUILD_TASK_GUIDANCE = `Build mode is the user's workspace: execute the approved plan, but an explicit user instruction always wins, even when it departs from the plan.
+- Apply user-ordered plan changes directly: edit the plan Markdown, keep the Implementation Steps list truthful, and say what changed; step statuses reconcile automatically.
+- Perform user-ordered work outside the plan without ceremony; report its effect on remaining steps.
+- Otherwise keep working the remaining steps in order.
 ${TASK_SELECTION_GUIDANCE}
 ${TASK_BOUNDARY_GUIDANCE}
 ${COMPLETION_GUIDANCE}
@@ -60,17 +63,17 @@ ${step}
 
 ${VERIFICATION_GUIDANCE}
 
-Verify only this step where possible. Defer checks dependent on later steps and report the deferral, never a pass. Do not edit approved Markdown or begin later steps. When this step and its applicable checks finish, call plan_step_complete with a concise summary; it completes immediately without user acceptance.
+Verify only this step where possible. Defer checks dependent on later steps and report the deferral, never a pass. Without a contrary user order, implement only this step and do not begin later steps; an explicit user instruction always takes precedence, including plan edits and out-of-plan work. When this step and its applicable checks finish, call plan_step_complete with a concise summary; it completes immediately without user acceptance.
 </system-reminder>`;
 }
 
 export function buildPlanStepWaitingReminder(progress: string, paused = false): string {
 	return `<system-reminder>
-${paused ? "Step execution is paused; retained progress grants no mutation authority. Resume explicitly before implementation." : "Step execution awaits the user's natural-language instruction."} No step is approved for project mutation.
+${paused ? "Step execution is paused; retained progress grants no mutation authority by default. Resume explicitly before implementation." : "Step execution awaits the user's natural-language instruction."} By default no step is approved for project mutation; an explicit user order always overrides.
 
 ${progress}
 
-Interpret clear intent contextually. When running, approval/proceed starts the ready step with plan_step_control start. A clear report that work is already finished may use complete; that records past work and authorizes no implementation. The same tool handles skip, revise, pause/resume, cancel, and panel visibility. Clarify ambiguity; ignore hypothetical or unrelated discussion. The sidebar is passive.
+Interpret clear intent contextually. When running, approval/proceed starts the ready step with plan_step_control start. A clear report that work is already finished may use complete; that records past work and authorizes no implementation. The same tool handles skip, revise, pause/resume, cancel, and panel visibility. An explicit user order is always followed—plan edits, out-of-plan work, and step actions included—and is never unrelated. Clarify ambiguity; ignore hypothetical discussion. The sidebar is passive.
 </system-reminder>`;
 }
 

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -469,7 +469,7 @@ test("phase-specific verification policy remains complete and bounded", () => {
 	assert.match(VERIFICATION_GUIDANCE, /Never weaken checks, claim an unperformed check passed, or fix unrelated failures/);
 
 	assert.ok(planning.length <= 3500, `planning context grew to ${planning.length} characters`);
-	assert.ok(build.length <= 3700, `Build context grew to ${build.length} characters`);
+	assert.ok(build.length <= 3900, `Build context grew to ${build.length} characters`);
 	assert.ok(step.length <= 1900, `step context grew to ${step.length} characters`);
 	assert.ok(handoff.length - "Approved plan".length <= 1200, `fresh handoff overhead grew to ${handoff.length} characters`);
 });
@@ -478,7 +478,7 @@ test("step execution prompts constrain work to an approved active step", () => {
 	const reminder = buildPlanStepReminder("/tmp/plan.md", 2, 4, "Build the parser");
 	assert.match(reminder, /only step 2 of 4/);
 	assert.match(reminder, /Build the parser/);
-	assert.match(reminder, /Do not edit approved Markdown or begin later steps/);
+	assert.match(reminder, /implement only this step and do not begin later steps/);
 	assert.match(reminder, /plan_step_complete/);
 	assert.match(reminder, /Verify only this step where possible/);
 	assert.match(reminder, /Defer checks dependent on later steps/);
@@ -486,7 +486,7 @@ test("step execution prompts constrain work to an approved active step", () => {
 	assert.match(PLAN_STEP_COMPLETE_DESCRIPTION, /after its implementation and applicable checks/);
 	assert.match(PLAN_STEP_COMPLETE_DESCRIPTION, /report later-step deferrals without claiming they passed/);
 	const waiting = buildPlanStepWaitingReminder("1. [ready] Build parser");
-	assert.match(waiting, /No step is approved for project mutation/);
+	assert.match(waiting, /By default no step is approved/);
 	assert.match(waiting, /Interpret clear intent contextually/);
 	assert.match(waiting, /work is already finished may use complete/);
 	assert.match(waiting, /approval\/proceed starts the ready step with plan_step_control start/);


### PR DESCRIPTION
## What

Two hard gates are removed from the `tool_call` hook:

- the plan-file read-only gate ("Current and historical plan files are read-only in Build mode")
- the no-active-step mutation gate ("no step is approved for project mutations")

Prompt guidance now states that explicit user instructions always take precedence, including plan edits and out-of-plan work; without a user order the agent still works the remaining steps in order. Plan mode remains fully read-only.

## Why

Mid-implementation, users legitimately discover plan changes ("update step 3, add a step here, do this now instead"). The gates forced the agent to refuse direct orders or fall back to the heavy escape hatches (`/plan abandon`, execution cancel), which reads as the extension ignoring the user.

## Keeping step tracking truthful

A `resyncPlanExecution` on plan-file tool results re-derives execution state from the edited Markdown: statuses match by normalized text (completed/skipped/active preserved), and the first pending step after the last done step becomes ready. Unparseable edits leave the last known state untouched.

Happy to reshape this as a config toggle (strict/flexible Build) if the default strictness must stay — say the word and I'll rework the branch.
