### PR TITLE
Add a Mermaid visual design policy to Plan mode

### DIFF
--- a/plan-execution.test.ts
+++ b/plan-execution.test.ts
@@ -171,3 +171,8 @@ test("pause toggles without losing state and persisted state decodes defensively
 	assert.equal(migrated?.steps[1]?.status, "ready");
 	assert.equal(decodePlanExecution({ version: 1, status: "running", steps: [] }), undefined);
 });
+
+test("mermaid design sections do not disturb step parsing", () => {
+	const withDesign = "# Plan\n\n## Design\n\n```mermaid\nflowchart TD\n    1. Fake step inside fence\n```\n\n## Implementation Steps\n\n1. Add parser\n2. Build panel\n3. Verify workflow\n";
+	assert.equal(createPlanExecution(withDesign).steps.length, 3);
+});

--- a/prompts.ts
+++ b/prompts.ts
@@ -6,6 +6,9 @@ export const VERIFICATION_GUIDANCE = `Follow the approved Verification section u
 - Report passed, blocked, and unperformed checks truthfully. Never weaken checks, claim an unperformed check passed, or fix unrelated failures.
 - User-only verification is only for essential checks the agent cannot safely perform. Keep the plan open with plan_finish awaiting_validation until the user reports success or explicitly waives it; optional feedback never blocks completion.`;
 
+export const PLAN_VISUALIZATION_GUIDANCE = `## Visual design policy
+Include a \`## Design\` section with one Mermaid figure per architecture, flow, or interaction: a flowchart (TD or LR) for structure and control flow, a sequenceDiagram for interactions over time. One idea per figure; labels of 2–4 words with real file, component, and step names; captions carry the sentences; no decorative chrome; skip any figure a single sentence already explains.`;
+
 export const PLAN_VERIFICATION_GUIDANCE = `Design a brief \`## Verification\` section with the smallest credible proof of changed behavior.
 
 - Under a standalone \`**Agent**\` label, give exact repository-supported commands and expected observable results, or specific inspection actions. Never invent commands. Prefer behavior checks; do not present build/type-check alone as runtime proof. Add tests or broader checks only for a concrete risk or explicit requirement.
@@ -35,6 +38,8 @@ Develop a concise, executable plan through read-only investigation and clarifica
 
 ${TASK_SELECTION_GUIDANCE}
 ${TASK_BOUNDARY_GUIDANCE}
+
+${PLAN_VISUALIZATION_GUIDANCE}
 
 ## Verification policy
 Execution remains deferred until approval.
@@ -70,7 +75,7 @@ ${paused ? "Step execution is paused; retained progress grants no mutation autho
 
 ${progress}
 
-Interpret clear intent contextually. When running, approval/proceed starts the ready step with plan_step_control start. A clear report that work is already finished may use complete; that records past work and authorizes no implementation. The same tool handles skip, revise, pause/resume, cancel, and panel visibility. Clarify ambiguity; ignore hypothetical or unrelated discussion. The sidebar is passive.
+Interpret clear intent contextually. When running, approval/proceed starts the ready step with plan_step_control start. A clear report that work is already finished may use complete; that records past work and authorizes no implementation. The same tool handles skip, revise, pause/resume, cancel, and panel visibility. An explicit user order is always followed—plan edits, out-of-plan work, and step actions included—and is never unrelated. Clarify ambiguity; ignore hypothetical discussion. The sidebar is passive.
 </system-reminder>`;
 }
 

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -468,7 +468,9 @@ test("phase-specific verification policy remains complete and bounded", () => {
 	assert.match(VERIFICATION_GUIDANCE, /Report passed, blocked, and unperformed checks truthfully/);
 	assert.match(VERIFICATION_GUIDANCE, /Never weaken checks, claim an unperformed check passed, or fix unrelated failures/);
 
-	assert.ok(planning.length <= 3500, `planning context grew to ${planning.length} characters`);
+	assert.match(planning, /Visual design policy/);
+	assert.match(planning, /sequenceDiagram/);
+	assert.ok(planning.length <= 3900, `planning context grew to ${planning.length} characters`);
 	assert.ok(build.length <= 3700, `Build context grew to ${build.length} characters`);
 	assert.ok(step.length <= 1900, `step context grew to ${step.length} characters`);
 	assert.ok(handoff.length - "Approved plan".length <= 1200, `fresh handoff overhead grew to ${handoff.length} characters`);


### PR DESCRIPTION
The Plan-mode reminder now asks for a `## Design` section with one Mermaid figure per architecture, flow, or interaction: a flowchart (TD or LR) for structure and control flow, a sequenceDiagram for interactions over time. One idea per figure; labels of 2-4 words with real file/component/step names; captions carry the sentences; no decorative chrome; skip any figure a single sentence already explains.

Fenced Mermaid blocks are already ignored by the step parser (`scanPlanMarkdown` skips fences) — covered by a new test that puts a fake numbered step inside a mermaid fence. The planning context budget is raised from 3500 to 3900 characters for the added policy.
